### PR TITLE
Psl 1619 dont show sections that have 0 results

### DIFF
--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -5,7 +5,7 @@ import { camelToStartCase } from '../../../utils';
 
 export type RenderSectionItemsList = (renderResultsArguments: {
   section: SectionConfiguration;
-}) => ReactElement;
+}) => ReactElement | null;
 
 type SectionItemsListProps = {
   section: SectionConfiguration;
@@ -16,6 +16,8 @@ type SectionItemsListProps = {
 // eslint-disable-next-line func-names
 const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ section }) {
   const sectionName = section?.displayName || section?.identifier;
+
+  if (!section?.data?.length) return null;
 
   return (
     <li className={`${sectionName} cio-section`} role='none'>

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -72,29 +72,36 @@ export function HooksTemplate(args) {
       </form>
       <div {...getMenuProps()}>
         {isOpen &&
-          sections?.map((section) => (
-            <div key={section.identifier} className={section.identifier}>
-              <div className='cio-section'>
-                <h5 className='cio-sectionName'>{section?.displayName || section.identifier}</h5>
-                <div className='cio-section-items'>
-                  {section?.data?.map((item, index) => (
-                    <div
-                      {...getItemProps({
-                        item,
-                        index,
-                        sectionIdentifier: section.identifier,
-                      })}
-                      key={item?.data?.id}>
-                      {isProduct(item) && (
-                        <img width='100%' src={item.data?.image_url} alt='' data-testid='cio-img' />
-                      )}
-                      <p>{item.value}</p>
-                    </div>
-                  ))}
+          sections?.map((section) =>
+            !section?.data?.length ? null : (
+              <div key={section.identifier} className={section.identifier}>
+                <div className='cio-section'>
+                  <h5 className='cio-sectionName'>{section?.displayName || section.identifier}</h5>
+                  <div className='cio-section-items'>
+                    {section?.data?.map((item, index) => (
+                      <div
+                        {...getItemProps({
+                          item,
+                          index,
+                          sectionIdentifier: section.identifier,
+                        })}
+                        key={item?.data?.id}>
+                        {isProduct(item) && (
+                          <img
+                            width='100%'
+                            src={item.data?.image_url}
+                            alt=''
+                            data-testid='cio-img'
+                          />
+                        )}
+                        <p>{item.value}</p>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          )}
       </div>
     </div>
   );
@@ -171,7 +178,7 @@ function YourComponent() {
       <div {...getMenuProps()}>
         {isOpen && (
           <>
-            {sections?.map((section) => (
+            {sections?.map((section) => !section?.data?.length ? null : (
               <div key={section.identifier} className={section.identifier}>
                 <div className='cio-section'>
                   <h5 className='cio-sectionName'>{section?.displayName || section.identifier}</h5>

--- a/src/styles.css
+++ b/src/styles.css
@@ -90,10 +90,15 @@
   border-radius: 4px;
 }
 
+.cio-autocomplete .Products {
+  padding: 0 5px;
+}
+
 .cio-autocomplete .Products .cio-item {
   display: inline-flex;
   align-items: center;
   width: 25%;
+  min-width: 130px;
   height: 140px;
   padding: 5px 0;
 }


### PR DESCRIPTION
 - Currently we will still show a section header even if there are no results to display.
 - In order to prevent confusion, we should not show a section with 0 results

Before this PR:
<img width="468" alt="Screenshot 2023-02-02 at 6 32 36 PM" src="https://user-images.githubusercontent.com/20070114/222520411-da058c1a-2123-4e58-a7d1-0a99dd76e069.png">

With changes in this PR:
<img width="1148" alt="Screenshot 2023-03-02 at 10 23 47 AM" src="https://user-images.githubusercontent.com/20070114/222520223-14f01d15-b5f6-422f-81d3-5ef9f8f23692.png">
<img width="1148" alt="Screenshot 2023-03-02 at 10 23 39 AM" src="https://user-images.githubusercontent.com/20070114/222520240-08a1ed09-b42b-491a-a024-fd756937a3ac.png">
<img width="1439" alt="Screenshot 2023-03-02 at 10 13 24 AM" src="https://user-images.githubusercontent.com/20070114/222520245-5e4c9cfa-b5f6-4962-96b4-c99ceae4ad56.png">
<img width="1439" alt="Screenshot 2023-03-02 at 10 13 14 AM" src="https://user-images.githubusercontent.com/20070114/222520249-f91e00b1-f088-4a5a-882f-d76830615eb4.png">
