### PR TITLE
[PARTI-505] Add GH actions based automation for publishing

### DIFF
--- a/.github/workflows/publish-create-github-release.yml
+++ b/.github/workflows/publish-create-github-release.yml
@@ -1,0 +1,56 @@
+name: 'Publish: Create GitHub release'
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        description: 'Version to publish'
+        required: true
+      title:
+        type: string
+        description: 'Release title'
+        required: true
+      deploy-sha:
+        type: string
+        description: 'Commit SHA to create release from'
+        required: true
+
+  # This workflow is intended to be called from the primary publish workflow
+  # automatically. The manual trigger is maintained for partially failed workflows
+  # or edge cases that require this be run independently.
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: 'Version to publish'
+        required: true
+      title:
+        type: string
+        description: 'Release title'
+        required: true
+      deploy-sha:
+        type: string
+        description: 'Commit SHA to create release from'
+        required: true
+
+jobs:
+  create-github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          name: ${{ inputs.title }}
+          tag: ${{ inputs.version }}
+          token: ${{ github.token }}
+          generateReleaseNotes: true
+          commit: ${{ inputs.deploy-sha}}
+      - name: Notify Slack about successful release
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          notification_title: "😸 New constructor-ui-autocomplete GitHub release created at version ${{ inputs.version }}"
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,52 @@
+name: 'Publish: Publish to NPM'
+
+on:
+  workflow_call:
+    inputs:
+      deploy-sha:
+        description: 'SHA of the commit to deploy'
+        required: true
+        type: string
+
+  # This workflow is intended to be called from the primary publish workflow
+  # automatically. The manual trigger is maintained for partially failed workflows
+  # or edge cases that require this be run independently.
+  workflow_dispatch:
+    inputs:
+      deploy-sha:
+        description: 'SHA of the commit to deploy'
+        required: true
+        type: string
+  
+jobs:
+  publish-to-npm:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.deploy-sha }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.12.x
+          registry-url: https://registry.npmjs.org/
+          scope: '@constructorio'
+          token: ${{ secrets.NPM_TOKEN }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Build compiled package for publishing
+        run: npm run compile
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Get new release version
+        id: get-version
+        run: echo "version=v$(npm pkg get version | tr -d '\"')" >> "$GITHUB_OUTPUT"
+      - name: Notify Slack about new publish to NPM
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          notification_title: "☁️ New constructor-ui-autocomplete release published to npm at version ${{ steps.get-version.outputs.version }}"
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,97 @@
+name: Publish
+
+on:
+  # This allows us to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      version-strategy:
+        type: choice
+        description: 'Version strategy'
+        required: true
+        options:
+            - 'patch'
+            - 'minor'
+            - 'major'
+        default: patch
+      title:
+        type: string
+        description: 'Release title'
+        required: true
+
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
+# We need these permissions create new GitHub releases
+permissions: write-all
+
+jobs:
+  update_package_version:
+    name: Update package version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack about new release
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          notification_title: "⏳ Starting new constructor-ui-autocomplete deployment"
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - uses: actions/checkout@v4
+      - uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.12.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Bump release version
+        run: npm version ${{ github.event.inputs.version-strategy }} -m "${{ github.event.inputs.title }}"
+      - name: Push main branch
+        run: git push origin main --follow-tags
+      - name: Set new release version
+        id: set-version
+        run: echo "version=v$(npm pkg get version | tr -d '\"')" >> "$GITHUB_OUTPUT"
+      - name: Set deployment SHA
+        id: set-deploy-sha
+        run: echo "deploy-sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Notify Slack about new package version
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          notification_title: "✅ constructor-ui-autocomplete package version bumped to ${{ steps.set-version.outputs.version }} successfully"
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    outputs:
+        version: ${{ steps.set-version.outputs.version }}
+        deploy-sha: ${{ steps.set-deploy-sha.outputs.deploy-sha }}
+  create_github_release:
+    name: Create GitHub release
+    needs: update_package_version
+    uses: ./.github/workflows/publish-create-github-release.yml
+    with:
+      version: ${{ needs.update_package_version.outputs.version }}
+      title: ${{ github.event.inputs.title }}
+      deploy-sha: ${{ needs.update_package_version.outputs.deploy-sha }}
+    secrets: inherit
+  publish_to_npm:
+    name: Publish to NPM
+    needs: update_package_version
+    uses: ./.github/workflows/publish-npm.yml
+    with:
+      deploy-sha: ${{ needs.update_package_version.outputs.deploy-sha }}
+    secrets: inherit
+  final_deployment_notification:
+    name: Final deployment notification
+    needs: [create_github_release, publish_to_npm]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Report deployment status to Slack
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          notification_title: "🏁 Constructor-ui-autocomplete deployment completed"
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@constructor-io/constructorio-ui-autocomplete",
-  "version": "1.9.2",
+  "version": "1.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@constructor-io/constructorio-ui-autocomplete",
-      "version": "1.9.2",
+      "version": "1.12.0",
       "license": "MIT",
       "devDependencies": {
         "@cspell/eslint-plugin": "^6.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@constructor-io/constructorio-ui-autocomplete",
-  "version": "1.9.2",
+  "version": "1.12.0",
   "description": "Constructor.io Autocomplete UI library for web applications",
   "main": "lib/cjs/index.js",
   "module": "lib/mjs/index.js",
@@ -35,8 +35,8 @@
     "serve-built-storybook": "npx http-server docs",
     "verify-node-version": "chmod +x ./scripts/verify-node-version.sh && ./scripts/verify-node-version.sh",
     "preversion": "node ./src/generateVersion.js",
-    "version": "npm run preversion && npm run verify-node-version && npm run build-storybook && git add -u ./docs && git add ./docs/* && git add ./src/version.ts && npm run compile",
-    "compile": "node ./src/generateVersion.js && rm -rf lib && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && npm run copy-styles && vite build"
+    "version": "npm run verify-node-version && npm run build-storybook && git add -u ./docs && git add ./docs/* && git add ./src/version.ts",
+    "compile": "rm -rf lib && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && npm run copy-styles && vite build"
   },
   "author": "constructor.io",
   "license": "MIT",


### PR DESCRIPTION
# PR Description
Adds some GH action based automations for publishing new versions of this package. Makes a small adjustment to the `version` npm script to accommodate these changes more cleanly (removes npm compile from this step since in the automation they are needed at different times). A detailed explanation of exactly what it should do follows:

## Steps
### Update package version
* Triggered manually from the GitHub Actions UI (could also be done with scripts or GH API if desired in the future, see the [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)  for this trigger type)
  * Receives the version strategy to use for incrementing the new version (major, minor, patch)
  * Receives the title to use for the new release, used in the GitHub release name
* Increments the version of the package using the pre-existing script so that storybook docs, node version check, and etc still execute
* Commits the new version and pushes back to this repository
* Captures the new version of the package and the commit sha from the commit it just created for use in future steps
### Create GitHub release
* Receives the release title, new version, and commit SHA from the update package version job and creates a GitHub release using it
### Publish to NPM
* Receives the commit SHA created in the update_package_version job
* Compiles the source code for distribution
* Publishes to NPM

**All steps provide Slack notifications about completion and the full workflow is wrapped in Slack notifications indicating the start and completion**

Each step listed besides `update_package_version` is its own separate workflow and job created using the [reusable workflow system](https://docs.github.com/en/actions/using-workflows/reusing-workflows), meaning they can be individually retried on failure or triggered independently of the bigger `Publish` workflow that composes them.

## What to test
* Workflow should successfully increment the version according to the provided version strategy
* The newly incremented version and correct new commit after versioning should be used for the GitHub release and NPM publish steps
* The NPM publish job (currently done with `--dry-run` to avoid real publishing) will output the files that it would bundle in the upload to NPM. Check that those look as they should.
* Slack notifications work properly through the whole process.

### For Customer Integrations Reviewers:
* Pay special attention to the `npm version` and `npm compile` commands run here and their context, ensure that these are consistent with the way that these are expected to be used in your current manual workflow and most importantly that the crtical end outputs will be the same.

## How to test
* Visit the [fork](https://github.com/Constructor-io/parti-505-constructorio-ui-autocomplete) that this PR is based on and run the `Publish` workflow from the Actions UI