### PR TITLE
Psl 3022 os UI ac add optional advanced param for debounce delay

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -225,3 +225,5 @@ To see this in action:
   - This is because we are filtering to the "Shirts" group`;
 
 export const termsWithImagesAndCountsDescription = `Pass boolean flags for \`displaySearchSuggestionImages\` and \`displaySearchSuggestionResultCounts\` fields to display images and counts for search suggestions. These fields need to be made displayable before they can be used. Please contact your Constructor Integration Engineer for details.`;
+
+export const debounceDescription = `Pass an integer to \`debounce\` to override the recommended, default delay employed for debouncing autocomplete network requests between keystrokes as your users type into the text input field. The default value is 250, which results in a debounce delay of 250 milliseconds.`;

--- a/src/hooks/useDebouncedFetchSections.ts
+++ b/src/hooks/useDebouncedFetchSections.ts
@@ -55,7 +55,7 @@ const useDebouncedFetchSection = (
   advancedParameters?: AdvancedParameters
 ) => {
   const [sectionsData, setSectionsData] = useState<AutocompleteResultSections>({});
-  const debouncedSearchTerm = useDebounce(query);
+  const debouncedSearchTerm = useDebounce(query, advancedParameters?.debounce);
 
   const { numTermsWithGroupSuggestions = 0, numGroupsSuggestedPerTerm = 0 } =
     advancedParameters || {};
@@ -63,6 +63,9 @@ const useDebouncedFetchSection = (
     const decoratedParameters: AdvancedParametersBase & IAutocompleteParameters = {
       ...advancedParameters,
     };
+
+    // eslint-disable-next-line no-param-reassign
+    delete decoratedParameters?.debounce;
 
     if (autocompleteSections) {
       decoratedParameters.resultsPerSection = autocompleteSections.reduce(

--- a/src/stories/Autocomplete/Component/AdvancedParameters.stories.tsx
+++ b/src/stories/Autocomplete/Component/AdvancedParameters.stories.tsx
@@ -10,6 +10,7 @@ import {
   apiKey,
   onSubmitDefault as onSubmit,
   termsWithImagesAndCountsDescription,
+  debounceDescription,
 } from '../../../constants';
 
 export default {
@@ -81,4 +82,18 @@ addComponentStoryDescription(
   TermsWithImagesAndCounts,
   `const args = ${stringifyWithDefaults(TermsWithImagesAndCounts.args)}`,
   termsWithImagesAndCountsDescription
+);
+
+export const Debounce = ComponentTemplate.bind({});
+Debounce.args = {
+  apiKey,
+  onSubmit,
+  advancedParameters: {
+    debounce: 100,
+  },
+};
+addComponentStoryDescription(
+  Debounce,
+  `const args = ${stringifyWithDefaults(Debounce.args)}`,
+  debounceDescription
 );

--- a/src/stories/Autocomplete/Hook/AdvancedParameters.stories.tsx
+++ b/src/stories/Autocomplete/Hook/AdvancedParameters.stories.tsx
@@ -10,6 +10,7 @@ import {
   apiKey,
   onSubmitDefault as onSubmit,
   termsWithImagesAndCountsDescription,
+  debounceDescription,
 } from '../../../constants';
 
 export default {
@@ -81,4 +82,18 @@ addHookStoryCode(
   TermsWithImagesAndCounts,
   `const args = ${stringifyWithDefaults(TermsWithImagesAndCounts.args)}`,
   termsWithImagesAndCountsDescription
+);
+
+export const Debounce = HooksTemplate.bind({});
+Debounce.args = {
+  apiKey,
+  onSubmit,
+  advancedParameters: {
+    debounce: 100,
+  },
+};
+addHookStoryCode(
+  Debounce,
+  `const args = ${stringifyWithDefaults(Debounce.args)}`,
+  debounceDescription
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface AdvancedParametersBase {
   numGroupsSuggestedPerTerm?: number;
   displaySearchSuggestionImages?: boolean;
   displaySearchSuggestionResultCounts?: boolean;
+  debounce?: number;
 }
 
 export type AdvancedParameters = AdvancedParametersBase &


### PR DESCRIPTION
Context
 - let's give consumers of our lib the ability to customize the debounce delay  for autocomplete network requests
 - motivation: [Mike and Ryan's feedback](https://constructor.slack.com/archives/C01F7U2BYGG/p1698353794756409?thread_ts=1698349445.798279&cid=C01F7U2BYGG)

What is the desired outcome?
 - add support AND documentation for option to customize [os-ui-autocomplete debounce delay in useDebounce](https://github.com/Constructor-io/constructorio-ui-autocomplete/blob/c9568d9d44b8fce4d410377543ddb22b76f11f7a/src/hooks/useDebounce.ts#L4) for both the hook and component lib interface