### PR TITLE
[CSL-3029] Update isProduct type guard

### DIFF
--- a/src/hooks/useFetchRecommendationPod.ts
+++ b/src/hooks/useFetchRecommendationPod.ts
@@ -19,13 +19,13 @@ const useFetchRecommendationPod = (
       );
       const recommendationPodResults = {};
 
-      responses.forEach(({ response }) => {
+      responses.forEach(({ response }, index) => {
         const { pod, results } = response;
         if (pod?.id) {
           recommendationPodResults[pod.id] = results?.map((item: Item) => ({
             ...item,
             id: item?.data?.id,
-            section: pod.id,
+            section: recommendationPods[index]?.section || 'Products',
           }));
         }
       });

--- a/src/hooks/useFetchRecommendationPod.ts
+++ b/src/hooks/useFetchRecommendationPod.ts
@@ -26,6 +26,7 @@ const useFetchRecommendationPod = (
             ...item,
             id: item?.data?.id,
             section: recommendationPods[index]?.section || 'Products',
+            podId: pod.id,
           }));
         }
       });

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -169,7 +169,7 @@ TypeSearchTermRenderRecommendations.play = async ({ canvasElement }) => {
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 };
 
 // - type search term => render all sections in default order
@@ -196,7 +196,7 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Search Suggestions');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('Products');
@@ -227,7 +227,7 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Products');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
@@ -307,7 +307,7 @@ FocusRenderZeroStateSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 };
 
 // - focus in input field with zero state and no open on focus => render no zero state section
@@ -391,7 +391,7 @@ ZeroStateRenderProductsSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -168,7 +168,7 @@ TypeSearchTermRenderRecommendations.play = async ({ canvasElement }) => {
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
 };
 
 // - type search term => render all sections in default order
@@ -195,7 +195,7 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Search Suggestions');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('Products');
@@ -226,7 +226,7 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Products');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
@@ -284,7 +284,7 @@ FocusRenderZeroStateSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
 };
 
 // - focus in input field with zero state and no open on focus => render no zero state section
@@ -368,7 +368,7 @@ ZeroStateRenderProductsSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByTestId('cio-item-bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
 
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 
 export function isProduct(item: Item): item is Product {
-  return (item as Product).section === 'Products';
+  return item.section !== 'Search Suggestions' && (item as Product).data?.image_url !== undefined;
 }
 
 export function isSearchSuggestion(item: Item): item is SearchSuggestion {

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -8,7 +8,7 @@ import {
 } from './types';
 
 export function isProduct(item: Item): item is Product {
-  return item.section !== 'Search Suggestions' && (item as Product).data?.image_url !== undefined;
+  return (item as Product).section === 'Products';
 }
 
 export function isSearchSuggestion(item: Item): item is SearchSuggestion {


### PR DESCRIPTION
The `isProduct` type guard was broken in [this PR](https://github.com/Constructor-io/constructorio-ui-autocomplete/pull/75/files#diff-9aea99b367f9871cb2e4c1a75340c75c63d6777954d9f882d06417d192d3894b). That PR incorrectly assumes anything outside of the `Products` section would be a non-product but that assumption is not correct. Recommendations would have a different section and could have an image. This PR reverts the type guard but also makes sure anything in `Search Suggestions` section will return false. 