### PR TITLE
[NO-CSL] Update camelToStartCase function

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,8 @@ export const camelToStartCase: CamelToStartCase = (camelCaseString) =>
     // insert a space before all caps
     .replace(/([A-Z])/g, ' $1')
     // uppercase the first character
-    .replace(/^./, (str) => str.toUpperCase());
+    .replace(/^./, (str) => str.toUpperCase())
+    .trim();
 
 export function isTrackingRequestSent(trackingRequestUrl) {
   // eslint-disable-next-line

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,11 +47,10 @@ type CamelToStartCase = (camelCaseString: string) => string;
 
 export const camelToStartCase: CamelToStartCase = (camelCaseString) =>
   camelCaseString
-    // insert a space before all caps
-    .replace(/([A-Z])/g, ' $1')
+    // insert a space before all caps except the first character
+    .replace(/(?!^)([A-Z])/g, ' $1')
     // uppercase the first character
-    .replace(/^./, (str) => str.toUpperCase())
-    .trim();
+    .replace(/^./, (str) => str.toUpperCase());
 
 export function isTrackingRequestSent(trackingRequestUrl) {
   // eslint-disable-next-line

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,10 +47,12 @@ type CamelToStartCase = (camelCaseString: string) => string;
 
 export const camelToStartCase: CamelToStartCase = (camelCaseString) =>
   camelCaseString
-    // insert a space before all caps except the first character
-    .replace(/(?!^)([A-Z])/g, ' $1')
-    // uppercase the first character
-    .replace(/^./, (str) => str.toUpperCase());
+    // insert a space between lower & upper
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    // space before last upper in a sequence followed by lower
+    .replace(/\b([A-Z]+)([A-Z])([a-z])/, '$1 $2$3')
+    // uppercase the first letter
+    .replace(/([a-zA-Z])/, (str) => str.toUpperCase());
 
 export function isTrackingRequestSent(trackingRequestUrl) {
   // eslint-disable-next-line


### PR DESCRIPTION
Before
![image](https://github.com/Constructor-io/constructorio-ui-autocomplete/assets/2954126/c0451d6e-d042-4049-bbb3-2e8fc219a154)

After
![image](https://github.com/Constructor-io/constructorio-ui-autocomplete/assets/2954126/f125b0eb-167c-44ff-8eff-eacac78e3717)

I think we should also revisit this function later because it assumes the starting string is camelCase but that's not always the case