### PR TITLE
Explicitly export types path in package.json exports so it can be resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     },
     ".": {
       "import": "./lib/mjs/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./cjs": {
       "import": "./lib/cjs/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./constructorio-ui-autocomplete-bundled": {
       "import": "./dist/constructorio-ui-autocomplete-bundled.js",


### PR DESCRIPTION
To reproduce the error that was caused by the absence of this

- npx create-next-app@latest
- cd your-app
- npm i @constructor-io/constructorio-ui-autocomplete
- Create a component and paste in the following snippet (in thread)
- Observe error in ticket in import statement for useCioAutocomplete




