### PR TITLE
Add AutocompleteSubmitEvent type predicates

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,8 @@ export type CioAutocompleteProps = CioClientConfig & {
 /**
  * AutocompleteSubmitEvent type is AutocompleteSelectSubmit or AutocompleteSearchSubmit.
  * Use isAutocompleteSearchSubmit or isAutocompleteSelectSubmit type predicates to safely access event properties.
+ * @example if (isAutocompleteSelectSubmit(event)) { ... } //`item` and `originalQuery` are available
+ * @example if (isAutocompleteSearchSubmit(event)) { ... } //`query` is available
  */
 export type AutocompleteSubmitEvent = AutocompleteSelectSubmit | AutocompleteSearchSubmit;
 
@@ -62,6 +64,7 @@ export type AutocompleteSearchSubmit = {
  * Checks if the provided event is an AutocompleteSelectSubmit event.
  * @param event The event to check.
  * @returns True if the event is an AutocompleteSelectSubmit event, false otherwise.
+ * @example if (isAutocompleteSelectSubmit(event)) { ... } // `query` is available
  */
 export const isAutocompleteSelectSubmit = (
   event: AutocompleteSubmitEvent
@@ -71,6 +74,7 @@ export const isAutocompleteSelectSubmit = (
  * Checks if the given event is an AutocompleteSearchSubmit event.
  * @param event The event to check.
  * @returns True if the event is an AutocompleteSearchSubmit event, false otherwise.
+ * @example if (isAutocompleteSearchSubmit(event)) { ... } // `item` and `originalQuery` are available
  */
 export const isAutocompleteSearchSubmit = (
   event: AutocompleteSubmitEvent

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,7 +43,38 @@ export type CioAutocompleteProps = CioClientConfig & {
   advancedParameters?: AdvancedParameters;
 };
 
-export type AutocompleteSubmitEvent = { item: Item; originalQuery: string } | { query: string };
+/**
+ * AutocompleteSubmitEvent type is AutocompleteSelectSubmit or AutocompleteSearchSubmit.
+ * Use isAutocompleteSearchSubmit or isAutocompleteSelectSubmit type predicates to safely access event properties.
+ */
+export type AutocompleteSubmitEvent = AutocompleteSelectSubmit | AutocompleteSearchSubmit;
+
+export type AutocompleteSelectSubmit = {
+  item: Item;
+  originalQuery: string;
+};
+
+export type AutocompleteSearchSubmit = {
+  query: string;
+};
+
+/**
+ * Checks if the provided event is an AutocompleteSelectSubmit event.
+ * @param event The event to check.
+ * @returns True if the event is an AutocompleteSelectSubmit event, false otherwise.
+ */
+export const isAutocompleteSelectSubmit = (
+  event: AutocompleteSubmitEvent
+): event is AutocompleteSelectSubmit => 'item' in event && 'originalQuery' in event;
+
+/**
+ * Checks if the given event is an AutocompleteSearchSubmit event.
+ * @param event The event to check.
+ * @returns True if the event is an AutocompleteSearchSubmit event, false otherwise.
+ */
+export const isAutocompleteSearchSubmit = (
+  event: AutocompleteSubmitEvent
+): event is AutocompleteSearchSubmit => 'query' in event;
 
 export type OnSubmit = (event: AutocompleteSubmitEvent) => unknown;
 


### PR DESCRIPTION
onSubmit event takes a union type as a parameter. Requiring that you add type guards before accessing any of the event object properties. Since this is a very common event. This PR Adds those type predicates with usage examples