### PR TITLE
[CSL-3168] Surface the Display Name of Recommendations Pod by Default

### DIFF
--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -212,8 +212,8 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
       'data-testid': 'cio-form',
     }),
     getSectionProps: (section: Section) => {
-      const { type, displayName } = section;
-      let sectionTitle = displayName;
+      const { type } = section;
+      let sectionTitle: string;
 
       // Add the indexSectionName as a class to the section container to make sure it gets the styles
       // Even if the section is a recommendation pod, if the results are "Products" or "Search Suggestions"
@@ -221,21 +221,19 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
       const indexSectionName =
         type !== 'custom' && section.indexSectionName ? toKebabCase(section.indexSectionName) : '';
 
-      if (!sectionTitle) {
-        switch (type) {
-          case 'recommendations':
-            sectionTitle = section.podId;
-            break;
-          case 'autocomplete':
-            sectionTitle = section.indexSectionName;
-            break;
-          case 'custom':
-            sectionTitle = section.displayName;
-            break;
-          default:
-            sectionTitle = section.indexSectionName;
-            break;
-        }
+      switch (type) {
+        case 'recommendations':
+          sectionTitle = section.podId;
+          break;
+        case 'autocomplete':
+          sectionTitle = section.displayName || section.indexSectionName;
+          break;
+        case 'custom':
+          sectionTitle = section.displayName;
+          break;
+        default:
+          sectionTitle = section.displayName || section.indexSectionName;
+          break;
       }
 
       const attributes: HTMLPropsWithCioDataAttributes = {

--- a/src/hooks/useFetchRecommendationPod.ts
+++ b/src/hooks/useFetchRecommendationPod.ts
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
 import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/types';
-import { Item, SectionsData, RecommendationsSectionConfiguration } from '../types';
+import { Item, SectionsData, RecommendationsSectionConfiguration, PodData } from '../types';
 
 const useFetchRecommendationPod = (
   cioClient: Nullable<ConstructorIOClient>,
   recommendationPods: RecommendationsSectionConfiguration[]
 ) => {
-  const [recommendationResults, setRecommendationResults] = useState<SectionsData>({});
+  const [recommendationsResults, setRecommendationsResults] = useState<SectionsData>({});
+  const [podsData, setPodsData] = useState<Record<string, PodData>>({});
 
   useEffect(() => {
     if (!cioClient || !Array.isArray(recommendationPods) || recommendationPods.length === 0) return;
@@ -20,22 +21,24 @@ const useFetchRecommendationPod = (
           })
         )
       );
-      const recommendationPodResults = {};
-
+      const recommendationsPodResults = {};
+      const recommendationsPodsData = {};
       responses.forEach(({ response }, index) => {
         const { pod, results } = response;
         if (pod?.id) {
-          recommendationPodResults[pod.id] = results?.map((item: Item) => ({
+          recommendationsPodResults[pod.id] = results?.map((item: Item) => ({
             ...item,
             id: item?.data?.id,
             section: recommendationPods[index]?.indexSectionName,
             podId: pod.id,
           }));
+          recommendationsPodsData[pod.id] = { displayName: pod.display_name, podId: pod.id };
         }
       });
 
       try {
-        setRecommendationResults(recommendationPodResults);
+        setRecommendationsResults(recommendationsPodResults);
+        setPodsData(recommendationsPodsData);
       } catch (error: any) {
         // eslint-disable-next-line no-console
         console.log(error);
@@ -45,7 +48,7 @@ const useFetchRecommendationPod = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cioClient]);
 
-  return recommendationResults;
+  return { recommendationsResults, podsData };
 };
 
 export default useFetchRecommendationPod;

--- a/src/hooks/useSections.ts
+++ b/src/hooks/useSections.ts
@@ -55,13 +55,33 @@ export default function useSections(
     cioClient,
     recommendationsSections
   );
+
+  // Merge Recommendation Pods Display Name from Dashboard
+  const activeSectionConfigs = useMemo(
+    () =>
+      activeSections.map((config: UserDefinedSection) => {
+        const mergedConfig = config;
+
+        if (isRecommendationsSection(config)) {
+          const podData = podsData[config.podId];
+          const libraryDisplayName = config.displayName;
+          const dashboardDisplayName = podData?.displayName;
+
+          mergedConfig.displayName = libraryDisplayName || dashboardDisplayName;
+        }
+
+        return mergedConfig;
+      }),
+    [activeSections, podsData]
+  );
+
   // Add to active sections the results data and refs when autocomplete results or recommendation results fetched
   useEffect(() => {
     const sectionsResults = { ...autocompleteResults, ...recommendationsResults };
     setActiveSectionsWithData(
-      getActiveSectionsWithData(activeSections, sectionsResults, sectionsRefs, podsData)
+      getActiveSectionsWithData(activeSectionConfigs, sectionsResults, sectionsRefs)
     );
-  }, [autocompleteResults, recommendationsResults, activeSections, podsData]);
+  }, [autocompleteResults, recommendationsResults, activeSectionConfigs, podsData]);
 
   return {
     activeSections,

--- a/src/hooks/useSections.ts
+++ b/src/hooks/useSections.ts
@@ -51,15 +51,17 @@ export default function useSections(
   );
 
   // Fetch Recommendations Results
-  const recommendationsResults = useFetchRecommendationPod(cioClient, recommendationsSections);
-
+  const { recommendationsResults, podsData } = useFetchRecommendationPod(
+    cioClient,
+    recommendationsSections
+  );
   // Add to active sections the results data and refs when autocomplete results or recommendation results fetched
   useEffect(() => {
     const sectionsResults = { ...autocompleteResults, ...recommendationsResults };
     setActiveSectionsWithData(
-      getActiveSectionsWithData(activeSections, sectionsResults, sectionsRefs)
+      getActiveSectionsWithData(activeSections, sectionsResults, sectionsRefs, podsData)
     );
-  }, [autocompleteResults, recommendationsResults, activeSections]);
+  }, [autocompleteResults, recommendationsResults, activeSections, podsData]);
 
   return {
     activeSections,

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -144,7 +144,7 @@ export function HooksTemplate(args) {
             return (
               <div key={sectionName} className={`${sectionName} ${recommendationsSection}`}>
                 <div {...getSectionProps(section)}>
-                  <h5 className='cio-sectionName'>{sectionName}</h5>
+                  <h5 className='cio-sectionName'>{section.displayName || sectionName}</h5>
                   <div className='cio-section-items'>
                     {section?.data?.map((item) => renderItem(item))}
                   </div>

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -186,7 +186,7 @@ TypeSearchTermRenderOverriddenRecommendationsDisplayName.args = {
     {
       podId: 'bestsellers',
       type: 'recommendations',
-      displayName: 'Our Best Sellers'
+      displayName: 'Our Best Sellers',
     },
   ],
 };

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -169,7 +169,32 @@ TypeSearchTermRenderRecommendations.play = async ({ canvasElement }) => {
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
-  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
+};
+
+// - Overwrite recommendations display name set at the dashboard
+export const TypeSearchTermRenderOverridedRecommendationsDisplayName = ComponentTemplate.bind({});
+TypeSearchTermRenderOverridedRecommendationsDisplayName.args = {
+  apiKey,
+  sections: [
+    {
+      indexSectionName: 'Search Suggestions',
+    },
+    {
+      indexSectionName: 'Products',
+    },
+    {
+      podId: 'bestsellers',
+      type: 'recommendations',
+      displayName: "Our Best Sellers"
+    },
+  ],
+};
+TypeSearchTermRenderOverridedRecommendationsDisplayName.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
+  await sleep(1000);
+  expect(canvas.getAllByText('Our Best Sellers').length).toBeGreaterThan(0);
 };
 
 // - type search term => render all sections in default order
@@ -196,7 +221,7 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Search Suggestions');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('Products');
@@ -227,7 +252,7 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Products');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
@@ -307,7 +332,7 @@ FocusRenderZeroStateSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 };
 
 // - focus in input field with zero state and no open on focus => render no zero state section
@@ -390,7 +415,7 @@ ZeroStateRenderProductsSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -186,7 +186,7 @@ TypeSearchTermRenderOverriddenRecommendationsDisplayName.args = {
     {
       podId: 'bestsellers',
       type: 'recommendations',
-      displayName: "Our Best Sellers"
+      displayName: 'Our Best Sellers'
     },
   ],
 };

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -173,8 +173,8 @@ TypeSearchTermRenderRecommendations.play = async ({ canvasElement }) => {
 };
 
 // - Overwrite recommendations display name set at the dashboard
-export const TypeSearchTermRenderOverridedRecommendationsDisplayName = ComponentTemplate.bind({});
-TypeSearchTermRenderOverridedRecommendationsDisplayName.args = {
+export const TypeSearchTermRenderOverriddenRecommendationsDisplayName = ComponentTemplate.bind({});
+TypeSearchTermRenderOverriddenRecommendationsDisplayName.args = {
   apiKey,
   sections: [
     {
@@ -190,7 +190,7 @@ TypeSearchTermRenderOverridedRecommendationsDisplayName.args = {
     },
   ],
 };
-TypeSearchTermRenderOverridedRecommendationsDisplayName.play = async ({ canvasElement }) => {
+TypeSearchTermRenderOverriddenRecommendationsDisplayName.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -179,7 +179,7 @@ TypeSearchTermRenderOverriddenRecommendationsDisplayName.args = {
     {
       podId: 'bestsellers',
       type: 'recommendations',
-      displayName: 'Our Best Sellers'
+      displayName: 'Our Best Sellers',
     },
   ],
 };

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -179,7 +179,7 @@ TypeSearchTermRenderOverriddenRecommendationsDisplayName.args = {
     {
       podId: 'bestsellers',
       type: 'recommendations',
-      displayName: "Our Best Sellers"
+      displayName: 'Our Best Sellers'
     },
   ],
 };

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -172,8 +172,8 @@ TypeSearchTermRenderRecommendations.play = async ({ canvasElement }) => {
 };
 
 // - Overwrite recommendations display name set at the dashboard
-export const TypeSearchTermRenderOverridedRecommendationsDisplayName = HooksTemplate.bind({});
-TypeSearchTermRenderOverridedRecommendationsDisplayName.args = {
+export const TypeSearchTermRenderOverriddenRecommendationsDisplayName = HooksTemplate.bind({});
+TypeSearchTermRenderOverriddenRecommendationsDisplayName.args = {
   apiKey,
   sections: [
     {
@@ -183,7 +183,7 @@ TypeSearchTermRenderOverridedRecommendationsDisplayName.args = {
     },
   ],
 };
-TypeSearchTermRenderOverridedRecommendationsDisplayName.play = async ({ canvasElement }) => {
+TypeSearchTermRenderOverriddenRecommendationsDisplayName.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -168,7 +168,27 @@ TypeSearchTermRenderRecommendations.play = async ({ canvasElement }) => {
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
+};
+
+// - Overwrite recommendations display name set at the dashboard
+export const TypeSearchTermRenderOverridedRecommendationsDisplayName = HooksTemplate.bind({});
+TypeSearchTermRenderOverridedRecommendationsDisplayName.args = {
+  apiKey,
+  sections: [
+    {
+      podId: 'bestsellers',
+      type: 'recommendations',
+      displayName: "Our Best Sellers"
+    },
+  ],
+};
+TypeSearchTermRenderOverridedRecommendationsDisplayName.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
+  await sleep(1000);
+  expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
+  expect(canvas.getAllByText('Our Best Sellers').length).toBeGreaterThan(0);
 };
 
 // - type search term => render all sections in default order
@@ -195,7 +215,7 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Search Suggestions');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('Products');
@@ -226,7 +246,7 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('Products');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
@@ -284,7 +304,7 @@ FocusRenderZeroStateSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 };
 
 // - focus in input field with zero state and no open on focus => render no zero state section
@@ -367,7 +387,7 @@ ZeroStateRenderProductsSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Best Sellers').length).toBeGreaterThan(0);
 
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,3 +183,8 @@ export type HTMLPropsWithCioDataAttributes<T = any> = React.DetailedHTMLProps<
 export type Translations = {
   in?: string;
 };
+
+export interface PodData {
+  podId: string;
+  displayName: string;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,20 +156,17 @@ export const getCioClient = (apiKey?: string, cioJsClientOptions?: ConstructorCl
 export const getActiveSectionsWithData = (
   activeSections: UserDefinedSection[],
   sectionResults: SectionsData,
-  sectionsRefs: React.MutableRefObject<React.RefObject<HTMLLIElement>[]>,
-  podsData: Record<string, PodData> = {}
+  sectionsRefs: React.MutableRefObject<React.RefObject<HTMLLIElement>[]>
 ) => {
   const activeSectionsWithData: Section[] = [];
 
   activeSections?.forEach((sectionConfig, index) => {
     const { type } = sectionConfig;
     let sectionData: Item[];
-    let displayName: string | undefined;
 
     switch (type) {
       case 'recommendations':
         sectionData = sectionResults[sectionConfig.podId];
-        displayName = podsData[sectionConfig.podId]?.displayName;
         break;
       case 'custom':
         // Copy id from data to the top level
@@ -186,7 +183,6 @@ export const getActiveSectionsWithData = (
     if (Array.isArray(sectionData)) {
       const section = {
         data: sectionData,
-        displayName,
         ...sectionConfig,
       };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import {
   ConstructorClientOptions,
 } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { isRecommendationsSection } from './typeGuards';
-import { Item, Section, UserDefinedSection, SectionsData, Translations, PodData } from './types';
+import { Item, Section, UserDefinedSection, SectionsData, Translations } from './types';
 import version from './version';
 
 export type GetItemPosition = (args: { item: Item; items: Item[] }) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -182,8 +182,8 @@ export const getActiveSectionsWithData = (
 
     if (Array.isArray(sectionData)) {
       const section = {
-        data: sectionData,
         ...sectionConfig,
+        data: sectionData,
       };
 
       // If ref passed as part of `SectionConfiguration`, use it.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import {
   ConstructorClientOptions,
 } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { isRecommendationsSection } from './typeGuards';
-import { Item, Section, UserDefinedSection, SectionsData, Translations } from './types';
+import { Item, Section, UserDefinedSection, SectionsData, Translations, PodData } from './types';
 import version from './version';
 
 export type GetItemPosition = (args: { item: Item; items: Item[] }) => {
@@ -156,17 +156,20 @@ export const getCioClient = (apiKey?: string, cioJsClientOptions?: ConstructorCl
 export const getActiveSectionsWithData = (
   activeSections: UserDefinedSection[],
   sectionResults: SectionsData,
-  sectionsRefs: React.MutableRefObject<React.RefObject<HTMLLIElement>[]>
+  sectionsRefs: React.MutableRefObject<React.RefObject<HTMLLIElement>[]>,
+  podsData: Record<string, PodData>
 ) => {
   const activeSectionsWithData: Section[] = [];
 
   activeSections?.forEach((sectionConfig, index) => {
     const { type } = sectionConfig;
     let sectionData: Item[];
+    let displayName: string | undefined;
 
     switch (type) {
       case 'recommendations':
         sectionData = sectionResults[sectionConfig.podId];
+        displayName = podsData[sectionConfig.podId]?.displayName;
         break;
       case 'custom':
         // Copy id from data to the top level
@@ -182,8 +185,9 @@ export const getActiveSectionsWithData = (
 
     if (Array.isArray(sectionData)) {
       const section = {
-        ...sectionConfig,
         data: sectionData,
+        displayName,
+        ...sectionConfig,
       };
 
       // If ref passed as part of `SectionConfiguration`, use it.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,7 +157,7 @@ export const getActiveSectionsWithData = (
   activeSections: UserDefinedSection[],
   sectionResults: SectionsData,
   sectionsRefs: React.MutableRefObject<React.RefObject<HTMLLIElement>[]>,
-  podsData: Record<string, PodData>
+  podsData: Record<string, PodData> = {}
 ) => {
   const activeSectionsWithData: Section[] = [];
 


### PR DESCRIPTION
## Summary
Recommendations Pod have a "display_name" attribute that we would want to render by default if available. If the user has specified a `displayName` configuration for the pod via the library, we should use that instead.
The css classnames should still reflect pod-id to avoid weird looking classnames such as `Best Sellers` rather than `best-sellers`.

## Changes Made
- `useFetchRecommendationsPod` now returns an additional object `podsData` which contains both the `podId` and `displayName` returned by the response.
- Consequently, `utils/getActiveSectionsWithData` now takes in the `podsData` as a new optional parameter.
- In `getSectionProps` in `useCioAutocomplete`, `sectionTitle` is used setting classnames and should reflect `podId` rather than `displayName`
- In `SectionItemList`, `sectionTitle` here is used to render to the end user and should reflect the `displayName` for Recs Pods, if available.