### PR TITLE
[CSL-3088] - fix issue with conflicting styles

### DIFF
--- a/.storybook/custom-styles-story.css
+++ b/.storybook/custom-styles-story.css
@@ -17,7 +17,7 @@
   right: 24px;
 }
 
-.cio-autocomplete.custom-autocomplete-styles .cio-sectionName {
+.cio-autocomplete.custom-autocomplete-styles .cio-section-name {
   margin: 5px 3px;
 }
 

--- a/.storybook/full-example-styles-story.css
+++ b/.storybook/full-example-styles-story.css
@@ -57,7 +57,7 @@
   right: 0;
 }
 
-.cio-autocomplete.full-example-autocomplete-styles .cio-sectionName {
+.cio-autocomplete.full-example-autocomplete-styles .cio-section-name {
   margin: 5px 3px;
 }
 

--- a/.storybook/full-example-styles-story.css
+++ b/.storybook/full-example-styles-story.css
@@ -72,25 +72,25 @@
   color: rgb(70, 70, 70);
 }
 
-.cio-autocomplete.full-example-autocomplete-styles .products.cio-section {
+.cio-autocomplete.full-example-autocomplete-styles .cio-section-products {
   padding: 0px;
 }
 
-.cio-autocomplete.full-example-autocomplete-styles .products .cio-item-Products {
+.cio-autocomplete.full-example-autocomplete-styles .cio-section-products .cio-item {
   width: 120px !important;
   height: fit-content;
   padding: 15px;
 }
 
-.cio-autocomplete.full-example-autocomplete-styles .products .cio-section-items {
+.cio-autocomplete.full-example-autocomplete-styles .cio-section-products .cio-section-items {
   text-align: center;
 }
 
-.cio-autocomplete.full-example-autocomplete-styles .products .cio-product-text {
+.cio-autocomplete.full-example-autocomplete-styles .cio-section-products .cio-product-text {
   padding: 15px 5px 0;
 }
 
-.cio-autocomplete.full-example-autocomplete-styles .products .cio-item .cio-product-image {
+.cio-autocomplete.full-example-autocomplete-styles .cio-section-products .cio-item .cio-product-image {
   width: 100%;
   height: 100%;
   min-height: 200px;
@@ -104,7 +104,7 @@
   border-radius: 0px;
 }
 
-.cio-autocomplete.full-example-autocomplete-styles .products p {
+.cio-autocomplete.full-example-autocomplete-styles .cio-section-products p {
   padding: 5px 5px 0;
 }
 
@@ -125,7 +125,7 @@
     width: unset;
   }
 
-  .cio-autocomplete.full-example-autocomplete-styles .Products.cio-section {
+  .cio-autocomplete.full-example-autocomplete-styles .cio-section-products {
     display: none;
   }
 }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ function YourComponent() {
             {sections?.map((section) => (
               <div key={section.indexSectionName} className={section.indexSectionName}>
                 <div className='cio-section'>
-                  <div className='cio-sectionName'>
+                  <div className='cio-section-name'>
                     {section?.displayName || section.indexSectionName}
                   </div>
                   <div className='cio-items'>

--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -41,7 +41,7 @@ const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ sectio
 
   return (
     <li {...getSectionProps(section)}>
-      <h5 className='cio-sectionName' aria-hidden>
+      <h5 className='cio-section-name' aria-hidden>
         {camelToStartCase(sectionTitle)}
       </h5>
       <ul className='cio-section-items' role='none'>

--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -39,9 +39,10 @@ const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ sectio
 
   if (!section?.data?.length) return null;
 
+  // @deprecated `cio-sectionName` will be removed in the next major release
   return (
     <li {...getSectionProps(section)}>
-      <h5 className='cio-section-name' aria-hidden>
+      <h5 className='cio-section-name cio-sectionName' aria-hidden>
         {camelToStartCase(sectionTitle)}
       </h5>
       <ul className='cio-section-items' role='none'>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -188,7 +188,7 @@ import '@constructor-io/constructorio-ui-autocomplete/styles.css';
   right: 24px;
 }
 
-.cio-autocomplete.custom-autocomplete-styles .cio-sectionName {
+.cio-autocomplete.custom-autocomplete-styles .cio-section-name {
   margin: 5px 3px;
 }
 

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -21,7 +21,7 @@ import {
 import useConsoleErrors from './useConsoleErrors';
 import useSections from './useSections';
 import useRecommendationsObserver from './useRecommendationsObserver';
-import { isAutocompleteSection, isRecommendationsSection } from '../typeGuards';
+import { isAutocompleteSection, isCustomSection, isRecommendationsSection } from '../typeGuards';
 
 export const defaultSections: UserDefinedSection[] = [
   {
@@ -212,39 +212,24 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
       'data-testid': 'cio-form',
     }),
     getSectionProps: (section: Section) => {
-      const { type, displayName } = section;
-      let sectionDisplayName = displayName;
-
-      // Add the indexSectionName as a class to the section container to make sure it gets the styles
+      // Always add the indexSectionName (defaults to Products) as a class to the section container for the styles
       // Even if the section is a recommendation pod, if the results are "Products" or "Search Suggestions"
       // ... they should be styled accordingly
-      const indexSectionName =
-        type !== 'custom' && section.indexSectionName ? toKebabCase(section.indexSectionName) : '';
-
-      if (!sectionDisplayName) {
-        switch (type) {
-          case 'recommendations':
-            sectionDisplayName = section.podId;
-            break;
-          case 'autocomplete':
-            sectionDisplayName = section.indexSectionName;
-            break;
-          case 'custom':
-            sectionDisplayName = section.displayName;
-            break;
-          default:
-            sectionDisplayName = section.indexSectionName;
-            break;
-        }
-      }
+      const sectionListingType = isCustomSection(section)
+        ? 'custom'
+        : toKebabCase(section.indexSectionName || section.data[0]?.section || 'Products');
 
       const attributes: HTMLPropsWithCioDataAttributes = {
-        className: `cio-section cio-section-${indexSectionName}`,
+        className: `cio-section cio-section-${sectionListingType}`,
         ref: section.ref,
         role: 'none',
         'data-cnstrc-section': section.data[0]?.section,
-        'data-cnstrc-display-name': sectionDisplayName,
       };
+
+      if (isCustomSection(section)) {
+        attributes['data-cnstrc-custom-section'] = true;
+        attributes['data-cnstrc-custom-section-name'] = section.displayName;
+      }
 
       // Add data attributes for recommendations
       if (isRecommendationsSection(section)) {

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -213,7 +213,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
     }),
     getSectionProps: (section: Section) => {
       const { type, displayName } = section;
-      let sectionTitle = displayName;
+      let sectionDisplayName = displayName;
 
       // Add the indexSectionName as a class to the section container to make sure it gets the styles
       // Even if the section is a recommendation pod, if the results are "Products" or "Search Suggestions"
@@ -221,19 +221,19 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
       const indexSectionName =
         type !== 'custom' && section.indexSectionName ? toKebabCase(section.indexSectionName) : '';
 
-      if (!sectionTitle) {
+      if (!sectionDisplayName) {
         switch (type) {
           case 'recommendations':
-            sectionTitle = section.podId;
+            sectionDisplayName = section.podId;
             break;
           case 'autocomplete':
-            sectionTitle = section.indexSectionName;
+            sectionDisplayName = section.indexSectionName;
             break;
           case 'custom':
-            sectionTitle = section.displayName;
+            sectionDisplayName = section.displayName;
             break;
           default:
-            sectionTitle = section.indexSectionName;
+            sectionDisplayName = section.indexSectionName;
             break;
         }
       }
@@ -243,7 +243,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
         ref: section.ref,
         role: 'none',
         'data-cnstrc-section': section.data[0]?.section,
-        'data-cnstrc-display-name': sectionTitle,
+        'data-cnstrc-display-name': sectionDisplayName,
       };
 
       // Add data attributes for recommendations

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -144,7 +144,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
 
       return {
         ...getItemProps({ item, index }),
-        className: `cio-item ${sectionItemTestId}`,
+        className: `cio-item`,
         'data-testid': sectionItemTestId,
       };
     },
@@ -239,10 +239,11 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
       }
 
       const attributes: HTMLPropsWithCioDataAttributes = {
-        className: `${sectionTitle} cio-section  ${indexSectionName}`,
+        className: `cio-section cio-section-${indexSectionName}`,
         ref: section.ref,
         role: 'none',
         'data-cnstrc-section': section.data[0]?.section,
+        'data-cnstrc-display-name': sectionTitle,
       };
 
       // Add data attributes for recommendations

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -144,7 +144,8 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
 
       return {
         ...getItemProps({ item, index }),
-        className: `cio-item`,
+        // @deprecated `sectionItemTestId` will be removed as a className in the next major version
+        className: `cio-item ${sectionItemTestId}`,
         'data-testid': sectionItemTestId,
       };
     },
@@ -212,6 +213,34 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
       'data-testid': 'cio-form',
     }),
     getSectionProps: (section: Section) => {
+      // @deprecated ClassNames derived from this fn will be removed in the next major version
+      const getDeprecatedClassNames = () => {
+        const { type } = section;
+        let sectionTitle: string;
+
+        const indexSectionName =
+          type !== 'custom' && section.indexSectionName
+            ? toKebabCase(section.indexSectionName)
+            : '';
+
+        switch (type) {
+          case 'recommendations':
+            sectionTitle = section.podId;
+            break;
+          case 'autocomplete':
+            sectionTitle = section.displayName || section.indexSectionName;
+            break;
+          case 'custom':
+            sectionTitle = section.displayName;
+            break;
+          default:
+            sectionTitle = section.displayName || section.indexSectionName;
+            break;
+        }
+
+        return `${sectionTitle} ${indexSectionName}`;
+      };
+
       // Always add the indexSectionName (defaults to Products) as a class to the section container for the styles
       // Even if the section is a recommendation pod, if the results are "Products" or "Search Suggestions"
       // ... they should be styled accordingly
@@ -220,7 +249,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
         : toKebabCase(section.indexSectionName || section.data[0]?.section || 'Products');
 
       const attributes: HTMLPropsWithCioDataAttributes = {
-        className: `cio-section cio-section-${sectionListingType}`,
+        className: `cio-section cio-section-${sectionListingType} ${getDeprecatedClassNames()}`,
         ref: section.ref,
         role: 'none',
         'data-cnstrc-section': section.data[0]?.section,

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import useCioAutocomplete from '../../../hooks/useCioAutocomplete';
 import { isRecommendationsSection } from '../../../typeGuards';
 import { Item } from '../../../types';
-import { getStoryParams, toKebabCase } from '../../../utils';
+import { camelToStartCase, getStoryParams, toKebabCase } from '../../../utils';
 
 export function HooksTemplate(args) {
   const {
@@ -119,32 +119,38 @@ export function HooksTemplate(args) {
             if (!section?.data?.length) {
               return null;
             }
+
             const { type, displayName } = section;
-            let sectionName = section.displayName;
+            let sectionTitle: string;
 
             switch (type) {
               case 'recommendations':
-                sectionName = section.podId;
+                sectionTitle = section.podId;
                 break;
               case 'custom':
-                sectionName = toKebabCase(displayName);
+                sectionTitle = displayName;
                 break;
               case 'autocomplete':
-                sectionName = section.indexSectionName;
+                sectionTitle = section.indexSectionName;
                 break;
               default:
-                sectionName = section.indexSectionName;
+                sectionTitle = section.indexSectionName;
                 break;
             }
 
-            const recommendationsSection = isRecommendationsSection(section)
-              ? section.indexSectionName
-              : '';
+            if (displayName) {
+              sectionTitle = displayName;
+            }
+
+            const sectionClassNames = toKebabCase(sectionTitle);
+            if (isRecommendationsSection(section)) {
+              sectionClassNames.concat(` ${toKebabCase(section.indexSectionName)}`);
+            }
 
             return (
-              <div key={sectionName} className={`${sectionName} ${recommendationsSection}`}>
+              <div key={sectionTitle} className={sectionClassNames}>
                 <div {...getSectionProps(section)}>
-                  <h5 className='cio-section-name'>{sectionName}</h5>
+                  <h5 className='cio-section-name'>{camelToStartCase(sectionTitle)}</h5>
                   <div className='cio-section-items'>
                     {section?.data?.map((item) => renderItem(item))}
                   </div>

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -142,9 +142,9 @@ export function HooksTemplate(args) {
               sectionTitle = displayName;
             }
 
-            const sectionClassNames = toKebabCase(sectionTitle);
+            let sectionClassNames = toKebabCase(sectionTitle);
             if (isRecommendationsSection(section)) {
-              sectionClassNames.concat(` ${toKebabCase(section.indexSectionName)}`);
+              sectionClassNames += ` ${toKebabCase(section.indexSectionName)}`;
             }
 
             return (

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -144,7 +144,7 @@ export function HooksTemplate(args) {
             return (
               <div key={sectionName} className={`${sectionName} ${recommendationsSection}`}>
                 <div {...getSectionProps(section)}>
-                  <h5 className='cio-sectionName'>{sectionName}</h5>
+                  <h5 className='cio-section-name'>{sectionName}</h5>
                   <div className='cio-section-items'>
                     {section?.data?.map((item) => renderItem(item))}
                   </div>
@@ -296,7 +296,7 @@ function YourComponent() {
             return (
               <div key={sectionName} className={\`\${sectionName} \${recommendationsSection}\`}>
                 <div {...getSectionProps(section)}>
-                  <h5 className='cio-sectionName'>{sectionName}</h5>
+                  <h5 className='cio-section-name'>{sectionName}</h5>
                   <div className='cio-section-items'>
                     {section?.data?.map((item) => renderItem(item))}
                   </div>

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import React from 'react';
 import useCioAutocomplete from '../../../hooks/useCioAutocomplete';
-import { isRecommendationsSection } from '../../../typeGuards';
+import { isCustomSection, isRecommendationsSection } from '../../../typeGuards';
 import { Item } from '../../../types';
 import { camelToStartCase, getStoryParams, toKebabCase } from '../../../utils';
 
@@ -121,8 +121,11 @@ export function HooksTemplate(args) {
             }
 
             const { type, displayName } = section;
-            let sectionTitle: string;
+            const sectionListingType = isCustomSection(section)
+              ? 'custom'
+              : toKebabCase(section.indexSectionName || section.data[0]?.section || 'Products');
 
+            let sectionTitle: string;
             switch (type) {
               case 'recommendations':
                 sectionTitle = section.podId;
@@ -142,9 +145,9 @@ export function HooksTemplate(args) {
               sectionTitle = displayName;
             }
 
-            let sectionClassNames = toKebabCase(sectionTitle);
+            let sectionClassNames = toKebabCase(sectionListingType);
             if (isRecommendationsSection(section)) {
-              sectionClassNames += ` ${toKebabCase(section.indexSectionName)}`;
+              sectionClassNames += ` ${toKebabCase(section.podId)}`;
             }
 
             return (

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -277,32 +277,38 @@ function YourComponent() {
             if (!section?.data?.length) {
               return null;
             }
+
             const { type, displayName } = section;
-            let sectionName = section.displayName;
+            let sectionTitle: string;
 
             switch (type) {
               case 'recommendations':
-                sectionName = section.podId;
+                sectionTitle = section.podId;
                 break;
               case 'custom':
-                sectionName = toKebabCase(displayName);
+                sectionTitle = displayName;
                 break;
               case 'autocomplete':
-                sectionName = section.indexSectionName;
+                sectionTitle = section.indexSectionName;
                 break;
               default:
-                sectionName = section.indexSectionName;
+                sectionTitle = section.indexSectionName;
                 break;
             }
 
-            const recommendationsSection = isRecommendationsSection(section)
-              ? section.indexSectionName
-              : '';
+            if (displayName) {
+              sectionTitle = displayName;
+            }
+
+            let sectionClassNames = toKebabCase(sectionTitle);
+            if (isRecommendationsSection(section)) {
+              sectionClassNames += \` \${toKebabCase(section.indexSectionName)}\`;
+            }
 
             return (
-              <div key={sectionName} className={\`\${sectionName} \${recommendationsSection}\`}>
+              <div key={sectionTitle} className={sectionClassNames}>
                 <div {...getSectionProps(section)}>
-                  <h5 className='cio-section-name'>{sectionName}</h5>
+                  <h5 className='cio-section-name'>{camelToStartCase(sectionTitle)}</h5>
                   <div className='cio-section-items'>
                     {section?.data?.map((item) => renderItem(item))}
                   </div>

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -234,6 +234,11 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   // bestsellers indexSectionName is products, and we render class based on that
   expect(canvas.getByTestId('cio-results').children[2].className).toContain('cio-section');
   expect(canvas.getByTestId('cio-results').children[2].className).toContain('cio-section-products');
+
+  // @deprecated The following classNames will be removed in the next major version
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain('Search Suggestions');
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('Products');
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain('bestsellers');
 };
 
 // - type search term => render all sections in custom order
@@ -273,6 +278,11 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-results').children[2].className).toContain(
     'cio-section-search-suggestions'
   );
+
+  // @deprecated The following classNames will be removed in the next major version
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain('Products');
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain('Search Suggestions');
 };
 
 // - select term suggestion => network tracking event

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -198,9 +198,12 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
   expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
-  expect(canvas.getByTestId('cio-results').children[0].className).toContain('Search Suggestions');
-  expect(canvas.getByTestId('cio-results').children[1].className).toContain('Products');
-  expect(canvas.getByTestId('cio-results').children[2].className).toContain('bestsellers');
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain(
+    'cio-section-search-suggestions'
+  );
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('cio-section-products');
+  // bestsellers indexSectionName is products, and we render class based on that
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain('cio-section-products');
 };
 
 // - type search term => render all sections in custom order
@@ -229,9 +232,12 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
   expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
-  expect(canvas.getByTestId('cio-results').children[0].className).toContain('Products');
-  expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
-  expect(canvas.getByTestId('cio-results').children[2].className).toContain('Search Suggestions');
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain('cio-section-products');
+  // bestsellers indexSectionName is products, and we render class based on that
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('cio-section-products');
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain(
+    'cio-section-search-suggestions'
+  );
 };
 
 // - select term suggestion => network tracking event

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -198,11 +198,16 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
   expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain('cio-section');
   expect(canvas.getByTestId('cio-results').children[0].className).toContain(
     'cio-section-search-suggestions'
   );
+
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('cio-section');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('cio-section-products');
+
   // bestsellers indexSectionName is products, and we render class based on that
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain('cio-section');
   expect(canvas.getByTestId('cio-results').children[2].className).toContain('cio-section-products');
 };
 
@@ -232,9 +237,14 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
   expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain('cio-section');
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('cio-section-products');
+
   // bestsellers indexSectionName is products, and we render class based on that
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('cio-section');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('cio-section-products');
+
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain('cio-section');
   expect(canvas.getByTestId('cio-results').children[2].className).toContain(
     'cio-section-search-suggestions'
   );

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -219,6 +219,7 @@ TypeSearchTermRenderSectionsCustomOrder.args = {
     },
   ],
 };
+// TODO: duplicate tests? these don't seem to run on npm run test-storybook
 TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -240,7 +240,7 @@ TypeSearchTermRenderSectionsCustomOrder.args = {
     },
   ],
 };
-// TODO: duplicate tests? these don't seem to run on npm run test-storybook
+
 TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -200,6 +200,7 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('search-suggestions');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('products');
   expect(canvas.getByTestId('cio-results').children[2].className).toContain('bestsellers');
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain('products');
 };
 
 // - type search term => render all sections in custom order
@@ -231,6 +232,7 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
 
   expect(canvas.getByTestId('cio-results').children[0].className).toContain('products');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('products');
   expect(canvas.getByTestId('cio-results').children[2].className).toContain('search-suggestions');
 };
 

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -168,7 +168,7 @@ TypeSearchTermRenderRecommendations.play = async ({ canvasElement }) => {
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 };
 
 // - type search term => render all sections in default order
@@ -195,10 +195,10 @@ TypeSearchTermRenderSectionsDefaultOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
-  expect(canvas.getByTestId('cio-results').children[0].className).toContain('Search Suggestions');
-  expect(canvas.getByTestId('cio-results').children[1].className).toContain('Products');
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain('search-suggestions');
+  expect(canvas.getByTestId('cio-results').children[1].className).toContain('products');
   expect(canvas.getByTestId('cio-results').children[2].className).toContain('bestsellers');
 };
 
@@ -227,11 +227,11 @@ TypeSearchTermRenderSectionsCustomOrder.play = async ({ canvasElement }) => {
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('red');
   expect(canvas.getAllByTestId('cio-item-SearchSuggestions').length).toBeGreaterThan(0);
   expect(canvas.getAllByTestId('cio-item-Products').length).toBeGreaterThan(0);
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
-  expect(canvas.getByTestId('cio-results').children[0].className).toContain('Products');
+  expect(canvas.getByTestId('cio-results').children[0].className).toContain('products');
   expect(canvas.getByTestId('cio-results').children[1].className).toContain('bestsellers');
-  expect(canvas.getByTestId('cio-results').children[2].className).toContain('Search Suggestions');
+  expect(canvas.getByTestId('cio-results').children[2].className).toContain('search-suggestions');
 };
 
 // - select term suggestion => network tracking event
@@ -285,7 +285,7 @@ FocusRenderZeroStateSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 };
 
 // - focus in input field with zero state and no open on focus => render no zero state section
@@ -368,7 +368,7 @@ ZeroStateRenderProductsSection.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('cio-input'));
   await sleep(1000);
   expect(canvas.getByTestId('cio-input').getAttribute('value')).toBe('');
-  expect(canvas.getAllByText('bestsellers').length).toBeGreaterThan(0);
+  expect(canvas.getAllByText('Bestsellers').length).toBeGreaterThan(0);
 
   await userEvent.type(canvas.getByTestId('cio-input'), 'red', { delay: 100 });
   await sleep(1000);

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,6 +61,8 @@
   margin-top: 5px;
 }
 
+/* @deprecated in favor of .cio-section-name */
+.cio-autocomplete .cio-sectionName,
 .cio-autocomplete .cio-section-name {
   margin: 15px 0;
   font-size: 1rem;
@@ -70,6 +72,8 @@
   padding: 0;
 }
 
+/* @deprecated in favor of .cio-section-search-suggestions */
+.cio-autocomplete .cio-item.cio-item-SearchSuggestions,
 .cio-autocomplete .cio-section-search-suggestions .cio-item {
   flex-direction: row;
   min-width: 160px;
@@ -92,10 +96,14 @@
   border-radius: 4px;
 }
 
+/* @deprecated in favor of .cio-section-products */
+.cio-autocomplete .products,
 .cio-autocomplete .cio-section-products {
   padding: 0 5px;
 }
 
+/* @deprecated in favor of .cio-section-products .cio-item */
+.cio-autocomplete .products .cio-item,
 .cio-autocomplete .cio-section-products .cio-item {
   display: inline-flex;
   align-items: center;

--- a/src/styles.css
+++ b/src/styles.css
@@ -61,7 +61,7 @@
   margin-top: 5px;
 }
 
-.cio-autocomplete .cio-sectionName {
+.cio-autocomplete .cio-section-name {
   margin: 15px 0;
   font-size: 1rem;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -70,7 +70,7 @@
   padding: 0;
 }
 
-.cio-autocomplete .cio-item.cio-item-SearchSuggestions {
+.cio-autocomplete .cio-section-search-suggestions .cio-item {
   flex-direction: row;
   min-width: 160px;
   justify-content: space-between;
@@ -92,11 +92,11 @@
   border-radius: 4px;
 }
 
-.cio-autocomplete .products {
+.cio-autocomplete .cio-section-products {
   padding: 0 5px;
 }
 
-.cio-autocomplete .products .cio-item {
+.cio-autocomplete .cio-section-products .cio-item {
   display: inline-flex;
   align-items: center;
   width: 25%;


### PR DESCRIPTION
What this change include? 
- removes sentence cased classnames from section list items & moves to `data-cnstrc-display-name` 
- prefixes kebab cased classname like so `cio-section-kebab-case-item-section` 
- keeps main classname 
Before: 
<img width="2037" alt="Screenshot 2024-01-24 at 17 16 33" src="https://github.com/Constructor-io/constructorio-ui-autocomplete/assets/21264255/f2fb81ec-31ec-4932-8bac-acb338acf786">
After: 
<img width="2001" alt="Screenshot 2024-01-24 at 17 08 54" src="https://github.com/Constructor-io/constructorio-ui-autocomplete/assets/21264255/40346c5a-70a0-4bb5-b7b5-f67f134cd092">
- removes unnecessary classname from section item 
<img width="1181" alt="Screenshot 2024-01-24 at 18 16 28" src="https://github.com/Constructor-io/constructorio-ui-autocomplete/assets/21264255/a968a9e4-b572-4589-963f-54aea643b141">


- task also includes criteria to "Make sectionName camelcase" but it already is 🤔 