### PR TITLE
[OS-Autocomplete-UI] - Fix Recommendations Example

### DIFF
--- a/.storybook/custom-styles-story.css
+++ b/.storybook/custom-styles-story.css
@@ -32,3 +32,21 @@
 .cio-autocomplete.custom-autocomplete-styles .products p {
   padding: 5px 5px 0;
 }
+
+.cio-autocomplete .cio-item .cio-product-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-align: center;
+}
+
+.cio-autocomplete .cio-item img.cio-product-image {
+  max-height: 200px;
+  object-fit: cover;
+  object-position: 50% 0%;
+}
+
+.cio-autocomplete .cio-section-products .cio-item.cio-item-Products {
+  height: unset;
+}


### PR DESCRIPTION
Styling fixes for text and images in Storybooks Hooks example

BEFORE
![image](https://github.com/Constructor-io/constructorio-ui-autocomplete/assets/1234692/79021256-62bb-4359-b5cf-38e55892c2ef)

AFTER
<img width="524" alt="Screenshot 2024-05-07 at 15 10 24" src="https://github.com/Constructor-io/constructorio-ui-autocomplete/assets/1234692/efef2576-c4b0-4bae-8fa5-1f0d86f706fc">
