### PR TITLE
Use default behavior for Home and End buttons

### DIFF
--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -187,7 +187,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
       className: 'cio-input',
       'data-testid': 'cio-input',
       placeholder,
-      onKeyDownCapture: ({ code, key }) => {
+      onKeyDownCapture: ({ code, key, nativeEvent }) => {
         const isEnter = code === 'Enter' || key === 'Enter';
         const isUserInput = highlightedIndex < 0;
         if (isOpen && isEnter && isUserInput && query?.length) {
@@ -200,6 +200,11 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
             // eslint-disable-next-line no-console
             console.log(error);
           }
+        }
+
+        if (code === 'Home' || code === 'End') {
+          // eslint-disable-next-line no-param-reassign
+          nativeEvent.preventDownshiftDefault = true;
         }
       },
     }),


### PR DESCRIPTION
Downshift default behavior for the "Home" and "End" buttons is to navigate to the first item and the last item on the dropdown. This PR removes this and defaults back to keyboard defaults. Which is go to the start of the input text or the end.