### PR TITLE
Refactor Suggestions components for clarity

### DIFF
--- a/src/components/Autocomplete/SectionItem/SectionItem.tsx
+++ b/src/components/Autocomplete/SectionItem/SectionItem.tsx
@@ -1,9 +1,7 @@
-import React, { ReactNode, useContext } from 'react';
-import { CioAutocompleteContext } from '../CioAutocompleteProvider';
+import React, { ReactNode } from 'react';
 import { Item } from '../../../types';
-import { isProduct, isInGroupSuggestion, isSearchSuggestion } from '../../../typeGuards';
-import SectionItemText from './SectionItemText';
-import { translate } from '../../../utils';
+import Suggestion from './Suggestion/Suggestion';
+import useCioAutocompleteContext from '../../../hooks/useCioAutocompleteContext';
 
 export interface SectionItemProps {
   item: Item;
@@ -12,77 +10,18 @@ export interface SectionItemProps {
   displaySearchTermHighlights?: boolean;
 }
 
-export default function SectionItem(props: SectionItemProps) {
-  const { item, children, displaySearchTermHighlights } = props;
-  const { getItemProps, advancedParameters, query, featureToggles } =
-    useContext(CioAutocompleteContext);
-  const { featureDisplaySearchSuggestionImages, featureDisplaySearchSuggestionResultCounts } =
-    featureToggles;
-  const {
-    displaySearchSuggestionImages = featureDisplaySearchSuggestionImages,
-    displaySearchSuggestionResultCounts = featureDisplaySearchSuggestionResultCounts,
-    translations,
-  } = advancedParameters || {};
-  let defaultChildren: ReactNode;
+export default function SectionItem({
+  item,
+  children,
+  displaySearchTermHighlights,
+}: SectionItemProps) {
+  const { getItemProps } = useCioAutocompleteContext();
 
-  if (isProduct(item)) {
-    defaultChildren = (
-      <>
-        <img
-          data-testid='cio-img'
-          src={item.data?.image_url}
-          alt={item.value}
-          className='cio-product-image'
-        />
-        <p data-testid='cio-text' className='cio-product-text'>
-          <SectionItemText
-            item={item}
-            query={query}
-            highlightSearchTerm={displaySearchTermHighlights}
-          />
-        </p>
-      </>
-    );
-  } else if (isInGroupSuggestion(item)) {
-    defaultChildren = (
-      <p className='cio-term-in-group'>
-        {translate('in', translations)}{' '}
-        <SectionItemText
-          item={item}
-          query={query}
-          highlightSearchTerm={displaySearchTermHighlights}
-        />
-      </p>
-    );
-  } else if (isSearchSuggestion(item)) {
-    defaultChildren = (
-      <>
-        {displaySearchSuggestionImages && item.data?.image_url && (
-          <img src={item.data?.image_url} alt={item.value} className='cio-suggestion-image' />
-        )}
-        <p className='cio-suggestion-text'>
-          <SectionItemText
-            item={item}
-            query={query}
-            highlightSearchTerm={displaySearchTermHighlights}
-          />
-        </p>
-        {displaySearchSuggestionResultCounts && item.data?.total_num_results && (
-          <p className='cio-suggestion-count'>({item.data?.total_num_results})</p>
-        )}
-      </>
-    );
-  } else {
-    defaultChildren = (
-      <p className='cio-custom-text'>
-        <SectionItemText
-          item={item}
-          query={query}
-          highlightSearchTerm={displaySearchTermHighlights}
-        />
-      </p>
-    );
-  }
-
-  return <li {...getItemProps(item)}>{children || defaultChildren}</li>;
+  return (
+    <li {...getItemProps(item)}>
+      {children || (
+        <Suggestion item={item} displaySearchTermHighlights={displaySearchTermHighlights} />
+      )}
+    </li>
+  );
 }

--- a/src/components/Autocomplete/SectionItem/SectionItemText.tsx
+++ b/src/components/Autocomplete/SectionItem/SectionItemText.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 import { Item } from '../../../types';
 import { isInGroupSuggestion } from '../../../typeGuards';
 import { escapeRegExp } from '../../../utils';
+import useCioAutocompleteContext from '../../../hooks/useCioAutocompleteContext';
 
 export interface SectionItemTextProps {
   item: Item;
-  query: string;
   highlightSearchTerm?: boolean;
 }
 
-export default function SectionItemText({
-  item,
-  query,
-  highlightSearchTerm,
-}: SectionItemTextProps) {
+export default function SectionItemText({ item, highlightSearchTerm }: SectionItemTextProps) {
+  const { query } = useCioAutocompleteContext();
+
   const itemText = isInGroupSuggestion(item) ? item.groupName : item.value;
 
   if (highlightSearchTerm) {

--- a/src/components/Autocomplete/SectionItem/Suggestion/CustomSuggestion.tsx
+++ b/src/components/Autocomplete/SectionItem/Suggestion/CustomSuggestion.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import SectionItemText from '../SectionItemText';
+import { Item } from '../../../../types';
+
+export interface CustomSuggestionProps {
+  item: Item;
+  displaySearchTermHighlights?: boolean;
+}
+
+export default function CustomSuggestion({
+  item,
+  displaySearchTermHighlights,
+}: CustomSuggestionProps) {
+  return (
+    <p className='cio-custom-text'>
+      <SectionItemText item={item} highlightSearchTerm={displaySearchTermHighlights} />
+    </p>
+  );
+}

--- a/src/components/Autocomplete/SectionItem/Suggestion/InGroupSearchSuggestion.tsx
+++ b/src/components/Autocomplete/SectionItem/Suggestion/InGroupSearchSuggestion.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import SectionItemText from '../SectionItemText';
+import { Item, Translations } from '../../../../types';
+import { translate } from '../../../../utils';
+
+export interface InGroupSearchSuggestionProps {
+  item: Item;
+  displaySearchTermHighlights?: boolean;
+  translations?: Translations;
+}
+
+export default function InGroupSearchSuggestion({
+  item,
+  displaySearchTermHighlights,
+  translations,
+}: InGroupSearchSuggestionProps) {
+  return (
+    <p className='cio-term-in-group'>
+      {translate('in', translations)}{' '}
+      <SectionItemText item={item} highlightSearchTerm={displaySearchTermHighlights} />
+    </p>
+  );
+}

--- a/src/components/Autocomplete/SectionItem/Suggestion/ProductSuggestion.tsx
+++ b/src/components/Autocomplete/SectionItem/Suggestion/ProductSuggestion.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import SectionItemText from '../SectionItemText';
+import { Item } from '../../../../types';
+
+export interface ProductSuggestionProps {
+  item: Item;
+  displaySearchTermHighlights?: boolean;
+}
+
+export default function ProductSuggestion({
+  item,
+  displaySearchTermHighlights,
+}: ProductSuggestionProps) {
+  return (
+    <>
+      <img
+        data-testid='cio-img'
+        src={item.data?.image_url}
+        alt={item.value}
+        className='cio-product-image'
+      />
+      <p data-testid='cio-text' className='cio-product-text'>
+        <SectionItemText item={item} highlightSearchTerm={displaySearchTermHighlights} />
+      </p>
+    </>
+  );
+}

--- a/src/components/Autocomplete/SectionItem/Suggestion/SearchSuggestion.tsx
+++ b/src/components/Autocomplete/SectionItem/Suggestion/SearchSuggestion.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import SectionItemText from '../SectionItemText';
+import { Item } from '../../../../types';
+import useCioAutocompleteContext from '../../../../hooks/useCioAutocompleteContext';
+
+export interface SearchSuggestionProps {
+  item: Item;
+  displaySearchTermHighlights?: boolean;
+}
+
+export default function SearchSuggestion({
+  item,
+  displaySearchTermHighlights,
+}: SearchSuggestionProps) {
+  const { advancedParameters, featureToggles } = useCioAutocompleteContext();
+
+  const { featureDisplaySearchSuggestionImages, featureDisplaySearchSuggestionResultCounts } =
+    featureToggles;
+  const {
+    displaySearchSuggestionImages = featureDisplaySearchSuggestionImages,
+    displaySearchSuggestionResultCounts = featureDisplaySearchSuggestionResultCounts,
+  } = advancedParameters || {};
+
+  return (
+    <>
+      {displaySearchSuggestionImages && item.data?.image_url && (
+        <img src={item.data?.image_url} alt={item.value} className='cio-suggestion-image' />
+      )}
+      <p className='cio-suggestion-text'>
+        <SectionItemText item={item} highlightSearchTerm={displaySearchTermHighlights} />
+      </p>
+      {displaySearchSuggestionResultCounts && item.data?.total_num_results && (
+        <p className='cio-suggestion-count'>({item.data?.total_num_results})</p>
+      )}
+    </>
+  );
+}

--- a/src/components/Autocomplete/SectionItem/Suggestion/Suggestion.tsx
+++ b/src/components/Autocomplete/SectionItem/Suggestion/Suggestion.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { isProduct, isInGroupSuggestion, isSearchSuggestion } from '../../../../typeGuards';
+import ProductSuggestion from './ProductSuggestion';
+import InGroupSearchSuggestion from './InGroupSearchSuggestion';
+import SearchSuggestion from './SearchSuggestion';
+import CustomSuggestion from './CustomSuggestion';
+import { Item } from '../../../../types';
+
+export interface SuggestionProps {
+  item: Item;
+  displaySearchTermHighlights?: boolean;
+}
+
+export default function Suggestion({ item, displaySearchTermHighlights }: SuggestionProps) {
+  if (isProduct(item)) {
+    return (
+      <ProductSuggestion item={item} displaySearchTermHighlights={displaySearchTermHighlights} />
+    );
+  }
+
+  if (isInGroupSuggestion(item)) {
+    return (
+      <InGroupSearchSuggestion
+        item={item}
+        displaySearchTermHighlights={displaySearchTermHighlights}
+      />
+    );
+  }
+
+  if (isSearchSuggestion(item)) {
+    return (
+      <SearchSuggestion item={item} displaySearchTermHighlights={displaySearchTermHighlights} />
+    );
+  }
+
+  return <CustomSuggestion item={item} displaySearchTermHighlights={displaySearchTermHighlights} />;
+}

--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -14,28 +14,26 @@ type SectionItemsListProps = {
   key?: string;
 };
 
+const getSectionTitle = (section: Section): string => {
+  const { type, displayName } = section;
+
+  switch (type) {
+    case 'recommendations':
+      return section.podId;
+    case 'autocomplete':
+      return section.indexSectionName;
+    case 'custom':
+      return displayName;
+    default:
+      return section.indexSectionName;
+  }
+};
+
 // eslint-disable-next-line func-names
 const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ section }) {
   const { getSectionProps } = useContext(CioAutocompleteContext);
-  const { type, displayName } = section;
-  let sectionTitle = displayName;
-
-  if (!sectionTitle) {
-    switch (type) {
-      case 'recommendations':
-        sectionTitle = section.podId;
-        break;
-      case 'autocomplete':
-        sectionTitle = section.indexSectionName;
-        break;
-      case 'custom':
-        sectionTitle = section.displayName;
-        break;
-      default:
-        sectionTitle = section.indexSectionName;
-        break;
-    }
-  }
+  const { displayName } = section;
+  const sectionTitle = camelToStartCase(displayName || getSectionTitle(section));
 
   if (!section?.data?.length) return null;
 
@@ -43,7 +41,7 @@ const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ sectio
   return (
     <li {...getSectionProps(section)}>
       <h5 className='cio-section-name cio-sectionName' aria-hidden>
-        {camelToStartCase(sectionTitle)}
+        {sectionTitle}
       </h5>
       <ul className='cio-section-items' role='none'>
         {section?.data?.map((item) => (

--- a/src/hooks/useCioAutocompleteContext.ts
+++ b/src/hooks/useCioAutocompleteContext.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { CioAutocompleteContext } from '../components/Autocomplete/CioAutocompleteProvider';
+
+const useCioAutocompleteContext = () => {
+  const contextObject = useContext(CioAutocompleteContext);
+  return contextObject;
+};
+
+export default useCioAutocompleteContext;


### PR DESCRIPTION
This introduces no logic changes. It's just organizing code into Components for clarity.

Before

 - Everything was inside `SectionItem` 

After

 - Suggestion
    - SearchSuggestion
    - ProductSuggestion
    - CustomSuggestion  
    - InGroupSearchSuggestion

Added `useCioAutocompleteContext` to make it clear what context is being used