### PR TITLE
Product suggestions are links by default

### DIFF
--- a/src/components/Autocomplete/SectionItem/SectionItem.tsx
+++ b/src/components/Autocomplete/SectionItem/SectionItem.tsx
@@ -27,7 +27,7 @@ export default function SectionItem(props: SectionItemProps) {
 
   if (isProduct(item)) {
     defaultChildren = (
-      <>
+      <a href={item.data?.url}>
         <img
           data-testid='cio-img'
           src={item.data?.image_url}
@@ -41,7 +41,7 @@ export default function SectionItem(props: SectionItemProps) {
             highlightSearchTerm={displaySearchTermHighlights}
           />
         </p>
-      </>
+      </a>
     );
   } else if (isInGroupSuggestion(item)) {
     defaultChildren = (

--- a/src/styles.css
+++ b/src/styles.css
@@ -91,6 +91,13 @@
   border-bottom: 3px solid transparent;
 }
 
+.cio-autocomplete .cio-item a {
+  color: inherit;
+  display: inline-flex;
+  text-decoration: inherit;
+  flex-direction: column;
+}
+
 .cio-autocomplete .cio-item[aria-selected='true'] {
   background-color: hsl(0, 0%, 90%);
   border-radius: 4px;
@@ -122,6 +129,7 @@
   width: 100%;
   max-width: 100px;
   max-height: 100px;
+  align-self: center;
 }
 
 .cio-autocomplete .cio-term-in-group {


### PR DESCRIPTION
No breaking changes

Markup Before
<img width="1421" alt="Screenshot 2024-09-12 at 12 35 11 AM" src="https://github.com/user-attachments/assets/a48a4521-2aab-4eac-8e60-0e22f9de70f4">


Markup after
<img width="1421" alt="Screenshot 2024-09-12 at 12 36 06 AM" src="https://github.com/user-attachments/assets/1091247e-e294-4ea3-90de-41845e936d2e">
