### PR TITLE
Undo memoizing all of props options and only memoize Objects/Arrays

### DIFF
--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -60,9 +60,6 @@ const convertLegacyParametersAndAddDefaults = (sections: UserDefinedSection[]) =
   });
 
 const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const memoizedOptions = useMemo(() => options, [JSON.stringify(options)]);
-
   const {
     onSubmit,
     onChange,
@@ -76,9 +73,9 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
     defaultInput,
     getSearchResultsUrl,
     onIsOpenChange,
-  } = memoizedOptions;
+  } = options;
 
-  let { sections = defaultSections, zeroStateSections } = memoizedOptions;
+  let { sections = defaultSections, zeroStateSections } = options;
 
   sections = useMemo(() => {
     if (sections) {
@@ -86,7 +83,8 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
     }
 
     return sections;
-  }, [sections]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(sections)]);
 
   zeroStateSections = useMemo(() => {
     if (zeroStateSections) {
@@ -94,7 +92,8 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
     }
 
     return zeroStateSections;
-  }, [zeroStateSections]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(zeroStateSections)]);
 
   const [query, setQuery] = useState(defaultInput || '');
   const previousQuery = usePrevious(query);

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -4,12 +4,12 @@ import { useMemo, useState } from 'react';
 import useCioClient from './useCioClient';
 import useDownShift from './useDownShift';
 import {
-  CioAutocompleteProps,
   CioClientConfig,
   Section,
   UserDefinedSection,
   HTMLPropsWithCioDataAttributes,
   Item,
+  UseCioAutocompleteOptions,
 } from '../types';
 import usePrevious from './usePrevious';
 import {
@@ -23,7 +23,8 @@ import {
 import useConsoleErrors from './useConsoleErrors';
 import useSections from './useSections';
 import useRecommendationsObserver from './useRecommendationsObserver';
-import { isAutocompleteSection, isCustomSection, isRecommendationsSection } from '../typeGuards';
+import { isCustomSection, isRecommendationsSection } from '../typeGuards';
+import useNormalizedProps from './useNormalizedProps';
 
 export const defaultSections: UserDefinedSection[] = [
   {
@@ -36,64 +37,21 @@ export const defaultSections: UserDefinedSection[] = [
   },
 ];
 
-export type UseCioAutocompleteOptions = Omit<CioAutocompleteProps, 'children'>;
-
-const convertLegacyParametersAndAddDefaults = (sections: UserDefinedSection[]) =>
-  sections.map((config) => {
-    if (isRecommendationsSection(config)) {
-      if (config.identifier && !config.podId) {
-        return { ...config, podId: config.identifier };
-      }
-
-      if (!config.indexSectionName) {
-        return { ...config, indexSectionName: 'Products' };
-      }
-    }
-
-    if (isAutocompleteSection(config)) {
-      if (config.identifier && !config.indexSectionName) {
-        return { ...config, indexSectionName: config.identifier };
-      }
-    }
-
-    return config;
-  });
-
 const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
+  const { sections, zeroStateSections, cioJsClientOptions, advancedParameters } =
+    useNormalizedProps(options);
   const {
     onSubmit,
     onChange,
     openOnFocus,
     apiKey,
     cioJsClient,
-    cioJsClientOptions,
     placeholder = 'What can we help you find today?',
     autocompleteClassName = 'cio-autocomplete',
-    advancedParameters,
     defaultInput,
     getSearchResultsUrl,
     onIsOpenChange,
   } = options;
-
-  let { sections = defaultSections, zeroStateSections } = options;
-
-  sections = useMemo(() => {
-    if (sections) {
-      return convertLegacyParametersAndAddDefaults(sections);
-    }
-
-    return sections;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(sections)]);
-
-  zeroStateSections = useMemo(() => {
-    if (zeroStateSections) {
-      return convertLegacyParametersAndAddDefaults(zeroStateSections);
-    }
-
-    return zeroStateSections;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(zeroStateSections)]);
 
   const [query, setQuery] = useState(defaultInput || '');
   const previousQuery = usePrevious(query);

--- a/src/hooks/useNormalizedProps.ts
+++ b/src/hooks/useNormalizedProps.ts
@@ -1,0 +1,83 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useMemo } from 'react';
+import { UseCioAutocompleteOptions, UserDefinedSection } from '../types';
+import { isAutocompleteSection, isRecommendationsSection } from '../typeGuards';
+
+export const defaultSections: UserDefinedSection[] = [
+  {
+    indexSectionName: 'Search Suggestions',
+    type: 'autocomplete',
+  },
+  {
+    indexSectionName: 'Products',
+    type: 'autocomplete',
+  },
+];
+
+const convertLegacyParametersAndAddDefaults = (sections: UserDefinedSection[]) =>
+  sections.map((config) => {
+    if (isRecommendationsSection(config)) {
+      if (config.identifier && !config.podId) {
+        return { ...config, podId: config.identifier };
+      }
+
+      if (!config.indexSectionName) {
+        return { ...config, indexSectionName: 'Products' };
+      }
+    }
+
+    if (isAutocompleteSection(config)) {
+      if (config.identifier && !config.indexSectionName) {
+        return { ...config, indexSectionName: config.identifier };
+      }
+    }
+
+    return config;
+  });
+
+const normalizeSections = (sections: UserDefinedSection[] | undefined) => {
+  if (sections) {
+    return convertLegacyParametersAndAddDefaults(sections);
+  }
+
+  return sections;
+};
+
+// Normalize and Memoize Objects to prevent infinite rerenders if users pass object literals to useCioAutocomplete
+const useNormalizedProps = (options: UseCioAutocompleteOptions) => {
+  const {
+    sections = defaultSections,
+    zeroStateSections,
+    cioJsClientOptions,
+    advancedParameters,
+  } = options;
+
+  const sectionsMemoized = useMemo(
+    () => normalizeSections(sections),
+    [JSON.stringify(sections)]
+  ) as UserDefinedSection[];
+
+  const zeroStateSectionsMemoized = useMemo(
+    () => normalizeSections(zeroStateSections),
+    [JSON.stringify(zeroStateSections)]
+  );
+
+  const cioJsClientOptionsMemoized = useMemo(
+    () => cioJsClientOptions,
+    [JSON.stringify(cioJsClientOptions)]
+  );
+
+  const advancedParametersMemoized = useMemo(
+    () => advancedParameters,
+    [JSON.stringify(advancedParameters)]
+  );
+
+  return {
+    sections: sectionsMemoized,
+    zeroStateSections: zeroStateSectionsMemoized,
+    cioJsClientOptions: cioJsClientOptionsMemoized,
+    advancedParameters: advancedParametersMemoized,
+  };
+};
+
+export default useNormalizedProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,8 @@ export type CioAutocompleteProps = CioClientConfig & {
   defaultInput?: string;
 };
 
+export type UseCioAutocompleteOptions = Omit<CioAutocompleteProps, 'children'>;
+
 /**
  * AutocompleteSubmitEvent type is AutocompleteSelectSubmit or AutocompleteSearchSubmit.
  * Use isAutocompleteSearchSubmit or isAutocompleteSelectSubmit type predicates to safely access event properties.


### PR DESCRIPTION
**Problem Statement**

1. We [memoized all props](https://github.com/Constructor-io/constructorio-ui-autocomplete/pull/158) to fix an issue with infinite rerenders when sections or zeroStateSections are passed directly to useCioAutocomplete as a literal array
2. This memoization introduced another issue where callback functions become stale

**Definition of Done:**

- Callback functions like `onSubmit` should have access to the most up-to-date values
- Passing object and array literals to `useCioAutocomplete` should not cause an infinite rerender

**How to reproduce:**

- add this to FullExampleTemplate in src/stories/Autocomplete/Component/index.TSX and then test on "Provide API Key" story
```
  const [x, setX] = useState('123');
  console.log(x); // This will have the most up to date value

  const onSubmit = () => {
    setX('456');
    console.log(x); // This will always log `123` even after x gets upated
  };
  
  return <CioAutocomplete {...args} onSubmit={onSubmit} />;
 

```

