### PR TITLE
Update IOS devices virtual keyboard search input mode

### DIFF
--- a/src/components/Autocomplete/SearchInput/SearchInput.tsx
+++ b/src/components/Autocomplete/SearchInput/SearchInput.tsx
@@ -12,7 +12,7 @@ function DefaultRenderInput({ getFormProps, getInputProps, getLabelProps, setQue
   return (
     <form {...getFormProps()}>
       <label {...getLabelProps()} htmlFor='cio-input'>
-        <input id='cio-input' {...inputProps} />
+        <input id='cio-input' {...inputProps} enterKeyHint='search' />
       </label>
       <button
         className='cio-clear-btn'


### PR DESCRIPTION
**Problem Statement:**

- On IOS devices interacting with autocomplete search input, a virtual keyboard appears with a "return" button (No call to action)
![IMG_4465](https://github.com/user-attachments/assets/96f15cd0-d4d6-4be4-b366-68d65a599ac3)

**Definition of done:**

- Update the search input mode to search so there's a "search" button (call to action)
![IMG_4466](https://github.com/user-attachments/assets/1566a890-2e1c-4fe6-a82e-4df22aa779e1)

**How to reproduce:** (You need an iPhone)

- Run storybook locally `npm run storybook:ci`
- Use ngrok to run `ngrok http http://localhost:6006`
- It will run a ngrok server and output a URL that you can open from your mobile device