### PR TITLE
Override default blur behavior

### DIFF
--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -25,6 +25,7 @@ import useSections from './useSections';
 import useRecommendationsObserver from './useRecommendationsObserver';
 import { isCustomSection, isRecommendationsSection } from '../typeGuards';
 import useNormalizedProps from './useNormalizedProps';
+import useCustomBlur from './useCustomBlur';
 
 export const defaultSections: UserDefinedSection[] = [
   {
@@ -91,6 +92,8 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
     previousQuery,
     ...rest,
   });
+
+  useCustomBlur(isOpen, closeMenu);
 
   // Log console errors
   useConsoleErrors(sections, activeSections);

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -93,7 +93,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
     ...rest,
   });
 
-  useCustomBlur(isOpen, closeMenu);
+  useCustomBlur(isOpen, closeMenu, autocompleteClassName);
 
   // Log console errors
   useConsoleErrors(sections, activeSections);

--- a/src/hooks/useCustomBlur.ts
+++ b/src/hooks/useCustomBlur.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect } from 'react';
 
-const useCustomBlur = (isOpen: boolean, closeMenu: () => void) => {
+const useCustomBlur = (isOpen: boolean, closeMenu: () => void, autocompleteClassName: string) => {
   const handleDocumentClick = useCallback(
     (event: MouseEvent) => {
-      if (isOpen && !(event.target as HTMLElement)?.closest('.cio-autocomplete')) {
+      if (isOpen && !(event.target as HTMLElement)?.closest(`.${autocompleteClassName}`)) {
         closeMenu();
       }
     },
-    [closeMenu, isOpen]
+    [closeMenu, isOpen, autocompleteClassName]
   );
 
   useEffect(() => {

--- a/src/hooks/useCustomBlur.ts
+++ b/src/hooks/useCustomBlur.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect } from 'react';
+
+const useCustomBlur = (isOpen: boolean, closeMenu: () => void) => {
+  const handleDocumentClick = useCallback(
+    (event: MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (isOpen && !(event.target as HTMLElement)?.closest('.cio-autocomplete')) {
+        closeMenu();
+      }
+    },
+    [closeMenu, isOpen]
+  );
+
+  useEffect(() => {
+    document.addEventListener('click', handleDocumentClick);
+    return () => {
+      document.removeEventListener('click', handleDocumentClick);
+    };
+  }, [handleDocumentClick]);
+};
+
+export default useCustomBlur;

--- a/src/hooks/useCustomBlur.ts
+++ b/src/hooks/useCustomBlur.ts
@@ -3,8 +3,6 @@ import { useCallback, useEffect } from 'react';
 const useCustomBlur = (isOpen: boolean, closeMenu: () => void) => {
   const handleDocumentClick = useCallback(
     (event: MouseEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
       if (isOpen && !(event.target as HTMLElement)?.closest('.cio-autocomplete')) {
         closeMenu();
       }
@@ -13,9 +11,9 @@ const useCustomBlur = (isOpen: boolean, closeMenu: () => void) => {
   );
 
   useEffect(() => {
-    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('mousedown', handleDocumentClick);
     return () => {
-      document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('mousedown', handleDocumentClick);
     };
   }, [handleDocumentClick]);
 };

--- a/src/hooks/useDownShift.ts
+++ b/src/hooks/useDownShift.ts
@@ -69,6 +69,15 @@ const useDownShift: UseDownShift = ({
         }
       }
     },
+    stateReducer: (state, actionAndChanges) => {
+      const { type, changes } = actionAndChanges;
+
+      // Override dropdown close on blur
+      if (type === useCombobox.stateChangeTypes.InputBlur) {
+        return { ...changes, isOpen: state.isOpen };
+      }
+      return changes;
+    },
     ...rest,
   });
 

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -482,7 +482,7 @@ InGroupSuggestions.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByTestId('cio-input'), 'socks', { delay: 100 });
   await sleep(1000);
-  expect(canvas.getAllByText('in Socks').length).toEqual(1);
+  expect(canvas.getAllByText('in Socks & Underwear').length).toEqual(1);
 };
 
 export const InGroupSuggestionsTwo = ComponentTemplate.bind({});

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -413,7 +413,7 @@ InGroupSuggestions.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByTestId('cio-input'), 'socks', { delay: 100 });
   await sleep(1000);
-  expect(canvas.getAllByText('in Socks').length).toEqual(1);
+  expect(canvas.getAllByText('in Socks & Underwear').length).toEqual(1);
 };
 
 export const InGroupSuggestionsTwo = HooksTemplate.bind({});


### PR DESCRIPTION
**Before** 

- The dropdown menu closes on Blur

**After**
- The dropdown menu closes on Blur AND click is not inside '.cio-autocomplete' element or its children