### PR TITLE
Support renderItem in vanilla JS

### DIFF
--- a/src/components/Autocomplete/SectionItem/CustomSectionItem.tsx
+++ b/src/components/Autocomplete/SectionItem/CustomSectionItem.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode, useContext, useMemo } from 'react';
+import { Item } from '../../../types';
+import { CioAutocompleteContext } from '../CioAutocompleteProvider';
+
+interface CustomItemProps {
+  item: Item;
+  renderItem: (props: {
+    item: Item;
+    query: string;
+    getItemProps: (item: Item) => any;
+  }) => HTMLElement | ReactNode;
+  query: string;
+}
+
+export default function CustomSectionItem(props: CustomItemProps) {
+  const { renderItem, item, query } = props;
+  const { getItemProps } = useContext(CioAutocompleteContext);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const customElement = useMemo(() => renderItem({ item, query, getItemProps }), [item]);
+
+  const isDomElement = customElement instanceof HTMLElement;
+  const isReactNode = React.isValidElement(customElement);
+
+  React.useEffect(() => {
+    if (isDomElement) {
+      if (ref.current) {
+        ref.current.innerHTML = ''; // Clear previous content
+        ref.current.appendChild(customElement);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item]);
+
+  if (isReactNode) {
+    return customElement;
+  }
+
+  if (isDomElement) {
+    return <div {...getItemProps(item)} ref={ref} />;
+  }
+  return null;
+}

--- a/src/components/Autocomplete/SectionItem/CustomSectionItem.tsx
+++ b/src/components/Autocomplete/SectionItem/CustomSectionItem.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext, useMemo } from 'react';
+import React, { ReactNode, useContext, useMemo, useEffect, useRef, isValidElement } from 'react';
 import { Item } from '../../../types';
 import { CioAutocompleteContext } from '../CioAutocompleteProvider';
 
@@ -15,20 +15,18 @@ interface CustomItemProps {
 export default function CustomSectionItem(props: CustomItemProps) {
   const { renderItem, item, query } = props;
   const { getItemProps } = useContext(CioAutocompleteContext);
-  const ref = React.useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const customElement = useMemo(() => renderItem({ item, query, getItemProps }), [item]);
 
   const isDomElement = customElement instanceof HTMLElement;
-  const isReactNode = React.isValidElement(customElement);
+  const isReactNode = isValidElement(customElement);
 
-  React.useEffect(() => {
-    if (isDomElement) {
-      if (ref.current) {
-        ref.current.innerHTML = ''; // Clear previous content
-        ref.current.appendChild(customElement);
-      }
+  useEffect(() => {
+    if (isDomElement && ref.current) {
+      ref.current.innerHTML = ''; // Clear previous content
+      ref.current.appendChild(customElement);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [item]);

--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -18,7 +18,7 @@ type SectionItemsListProps = {
 
 // eslint-disable-next-line func-names
 const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ section }) {
-  const { getSectionProps, query, getFormProps, advancedParameters, getItemProps } =
+  const { getSectionProps, query, getFormProps, advancedParameters } =
     useContext(CioAutocompleteContext);
   const { displayShowAllResultsButton, translations } = advancedParameters || {};
   const { onSubmit } = getFormProps();

--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useContext } from 'react';
 import { Section } from '../../../types';
 import SectionItem from '../SectionItem/SectionItem';
+import CustomSectionItem from '../SectionItem/CustomSectionItem';
 import { camelToStartCase, translate } from '../../../utils';
 import { CioAutocompleteContext } from '../CioAutocompleteProvider';
 import NoResults from '../AutocompleteResults/NoResults';
@@ -63,7 +64,14 @@ const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ sectio
       <ul className='cio-section-items' role='none'>
         {section?.data?.map((item) => {
           if (typeof section?.renderItem === 'function') {
-            return section.renderItem({ item, query, getItemProps });
+            return (
+              <CustomSectionItem
+                renderItem={section.renderItem}
+                item={item}
+                query={query}
+                key={item.id}
+              />
+            );
           }
           return (
             <SectionItem

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -262,5 +262,6 @@ export const translationsDescription = `Pass a \`translations\` object to displa
 
 export const customRenderItemDescription = `Customize the rendering of individual items within a Section by providing a \`renderItem\` function. This function allows you to define how each item should be rendered.
 - Make sure to call \`getItemProps(item)\` and spread like this \`<div {...getItemProps(item)}/>\` on the container of each custom rendered item or else tracking will not work.
+- Supports both ReactNode and HTMLElement as a return type
 `;
 export const displayShowAllResultsButtonDescription = `Pass a boolean to \`displayShowAllResultsButton\` to display a button at the bottom of the Products section to show all results. This button will submit the form and trigger the \`onSubmit\` callback.`;


### PR DESCRIPTION
To test the custom HTMLElement as a return type for `renderItem` use this on `CustomRenderItem` item

```
renderItem: ({ item }) => {
  const div = document.createElement('div');
  const img = document.createElement('img');
  img.src = item.data.image_url;
  img.alt = item.value;
  const name = document.createElement('div');
  name.textContent = item.value;
  const price = document.createElement('div');
  price.textContent = item.data.price;
  const button = document.createElement('button');
  button.textContent = 'Add to Cart';
  div.appendChild(img);
  div.appendChild(name);
  div.appendChild(price);
  div.appendChild(button);
  return div;
},
```