### PR TITLE
Fix custom blur

### DIFF
--- a/src/hooks/useCustomBlur.ts
+++ b/src/hooks/useCustomBlur.ts
@@ -3,7 +3,8 @@ import { useCallback, useEffect } from 'react';
 const useCustomBlur = (isOpen: boolean, closeMenu: () => void, autocompleteClassName: string) => {
   const handleDocumentClick = useCallback(
     (event: MouseEvent) => {
-      if (isOpen && !(event.target as HTMLElement)?.closest(`.${autocompleteClassName}`)) {
+      const classNames = autocompleteClassName.split(' ').join('.');
+      if (isOpen && !(event.target as HTMLElement)?.closest(`.${classNames}`)) {
         closeMenu();
       }
     },


### PR DESCRIPTION
🐛  **The bug**

- The custom blur hook breaks the click events if and only uf `autocompleteClassName` consists of multiple class names, ie

    - `cio-autocomplete custom-autocomplete-styles` 



🔁  **How to reproduce the bug?**

- Selects are broken on the full featured [example](https://constructor-io.github.io/constructorio-ui-autocomplete/?path=/story/autocomplete-component--full-featured-and-styled-example) since it has 
 
    - `autocompleteClassName = 'cio-autocomplete custom-autocomplete-styles';`


✅ **The fix**
- Handle multiple class names by splitting and joining them again