### PR TITLE
[CI-4320] Create a Props.mdx for CioAutocomplete

### DIFF
--- a/src/stories/components/CioAutocomplete/CioAutocomplete.stories.tsx
+++ b/src/stories/components/CioAutocomplete/CioAutocomplete.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { CioAutocomplete, CioAutocompleteProps } from '../../../index';
+import { componentDescription, apiKey } from '../../../constants';
+
+const meta: Meta<typeof CioAutocomplete> = {
+  title: 'Components/CioAutocomplete',
+  component: CioAutocomplete,
+  parameters: {
+    docs: {
+      description: {
+        component: componentDescription,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function StoryTemplate({ args }: { args: CioAutocompleteProps }) {
+  return <CioAutocomplete {...args} />;
+}
+
+export const PrimaryStory: Story = {
+  render: (args) => <StoryTemplate args={args} />,
+  args: {
+    apiKey,
+  },
+};

--- a/src/stories/components/CioAutocomplete/CioAutocompleteProps.mdx
+++ b/src/stories/components/CioAutocomplete/CioAutocompleteProps.mdx
@@ -1,0 +1,8 @@
+import { Meta, Markdown, ArgTypes } from '@storybook/blocks';
+import * as CioAutocompleteStories from './CioAutocomplete.stories';
+
+<Meta of={CioAutocompleteStories} />
+
+## Props
+
+<ArgTypes />

--- a/src/stories/components/CioAutocomplete/CioAutocompleteProps.mdx
+++ b/src/stories/components/CioAutocomplete/CioAutocompleteProps.mdx
@@ -1,7 +1,7 @@
 import { Meta, Markdown, ArgTypes } from '@storybook/blocks';
 import * as CioAutocompleteStories from './CioAutocomplete.stories';
 
-<Meta of={CioAutocompleteStories} />
+<Meta name='Props' of={CioAutocompleteStories} />
 
 ## Props
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,8 +15,17 @@ import {
 export type { IAutocompleteParameters } from '@constructor-io/constructorio-client-javascript/lib/types';
 
 export type CioClientConfig = {
+  /**
+   * Your Constructor API key. Either `apiKey` or `cioJsClient` are required
+   */
   apiKey?: string;
+  /**
+   * Optional custom constructor instance. Either `apiKey` or `cioJsClient` are required
+   */
   cioJsClient?: ConstructorIOClient;
+  /**
+   * If you don't want to create an instance of the `ConstructorIOClient` but still want to customize some of the options, you can pass a `cioJsClientOptions` object. You can learn more about the possible values [Here](https://constructor-io.github.io/constructorio-client-javascript/ConstructorIO.html)
+   */
   cioJsClientOptions?: ConstructorClientOptions;
 };
 
@@ -35,17 +44,55 @@ export type AdvancedParameters = AdvancedParametersBase &
   Omit<IAutocompleteParameters, 'resultsPerSection'>;
 
 export type CioAutocompleteProps = CioClientConfig & {
+  /**
+   * Set to `false` to show suggestions only after a user clears their query,
+   * but not when they initially select the input
+   */
   openOnFocus?: boolean;
+  /**
+   * Function that takes in a Search Suggestion, and returns a url to redirect to
+   */
   getSearchResultsUrl?: (item: SearchSuggestion) => string;
+  /**
+   * Callback function that runs when the user submits a search.
+   * Usually used to trigger a redirect
+   */
   onSubmit: OnSubmit;
+  /**
+   * Callback function that runs when the user focuses on the input
+   */
   onFocus?: () => void;
+  /**
+   * Callback function that runs when the user modifies input
+   */
   onChange?: (input: string) => void;
+  /**
+   * Search input placeholder
+   */
   placeholder?: string;
+  /**
+   * Children to be rendered according to the RenderProps pattern
+   */
   children?: ReactNode;
+  /**
+   * Override the sections that will be rendered. Defaults to Products and Search Suggestion sections
+   */
   sections?: UserDefinedSection[];
+  /**
+   * Custom sections that should be rendered during the autocomplete zero state
+   */
   zeroStateSections?: UserDefinedSection[];
+  /**
+   * Override the parent container's class. Defaults to `cio-autocomplete`
+   */
   autocompleteClassName?: string;
+  /**
+   * See Advanced Parameters
+   */
   advancedParameters?: AdvancedParameters;
+  /**
+   * Search input default value
+   */
   defaultInput?: string;
 };
 


### PR DESCRIPTION
This PR creates a Props table for the `CioAutocomplete` table in a platform agnostic way. This is done through type-annotations, and can be migrated off Storybook through the use of [react-docgen](https://github.com/reactjs/react-docgen?tab=readme-ov-file) and/or [react-props-md-table](https://github.com/TeamWertarbyte/react-props-md-table?tab=readme-ov-file).

A new folder is created to conform to the new, recommended [Storybook Project Hierarchy](https://constructor.slab.com/posts/os-ui-api-reference-guide-708f4fb4#hu0rw-storybook-file-hierarchy). The old docs are left untouched in case other engineers are in the process of migrating them and can be merged in a future PR.

### Possible Enhancements
Currently, the "default values" column is left unfilled since `CioAutocomplete` doesn't have default values for these props. We can either have the default prop values explicitly set, or add some css to hide that column entirely.

We might want to add an "Advanced Parameters" table as well.