### PR TITLE
[CI-4265] Add License to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,6 @@ dist
 .pnp.*
 
 # Storybook
-docs
+/docs
 
 .DS_Store

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,10 +1,14 @@
 module.exports = {
-  stories: ['../src/**/Autocomplete/**/*.stories.mdx', '../src/**/Autocomplete/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: [
+    '../src/**/*.mdx',
+    '../src/**/*.stories.@(js|jsx|ts|tsx)',
+  ],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    '@storybook/addon-a11y'
+    '@storybook/addon-a11y',
+    '@storybook/addon-docs',
   ],
   framework: {
     name: '@storybook/react-webpack5',
@@ -13,4 +17,4 @@ module.exports = {
   docs: {
     autodocs: true
   }
-};
+}; 

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,1 +1,6 @@
 <link rel="icon" type="image/png" sizes="16x16" href="https://docs.constructor.io/img/favicon.ico">
+<style>
+  [data-item-id=autocomplete-hook--basic-usage] {
+    display: none !important;
+  }
+</style>

--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -22,6 +22,11 @@ export const parameters = {
     'storybook/docs/panel': { index: -1 }
   },
   docs: {
+    toc: {
+      disable: false,
+      headingSelector: 'h3, h4, h5',
+      ignoreSelector: '.docs-story h2, .docs-story h3',
+    },
     page: () => (
       <>
         <Title />

--- a/.storybook/storybook-styles.css
+++ b/.storybook/storybook-styles.css
@@ -1,4 +1,8 @@
-.docs-story > div:first-child {
+.docs-story>div:first-child {
   min-height: 500px;
   background-color: #212425;
+}
+
+[data-item-id="autocomplete-hook--basic-usage"] {
+  display: none;
 }

--- a/README.md
+++ b/README.md
@@ -229,3 +229,8 @@ Dispatch the [Deploy Storybook](https://github.com/Constructor-io/constructorio-
 ## Usage examples
 - [Javascript](https://codesandbox.io/s/autocomplete-ui-integration-plain-y9zjl7)
 - [Remix App](https://codesandbox.io/p/sandbox/remix-example-for-constructorio-ui-autocomplete-kk5vh5?file=%2Fapp%2Froutes%2Findex.tsx)
+
+
+## License
+[MIT License](./LICENSE)
+Copyright (c) 2022-present Constructor.io Corporation

--- a/README.md
+++ b/README.md
@@ -233,4 +233,5 @@ Dispatch the [Deploy Storybook](https://github.com/Constructor-io/constructorio-
 
 ## License
 [MIT License](./LICENSE)
-Copyright (c) 2022-present Constructor.io Corporation
+
+Copyright (c) 2022-present Constructor

--- a/cspell.json
+++ b/cspell.json
@@ -25,6 +25,7 @@
     "subcomponents",
     "testid",
     "cnstrc",
-    "dans"
+    "dans",
+    "autodocs"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test-storybook:watch": "test-storybook --watch",
     "test-storybook:ci": "start-server-and-test storybook:ci http://localhost:6006 test-storybook",
     "build-storybook": "storybook build -o 'docs'",
+    "build-storybook-docs": "storybook build --docs -o 'docs'",
     "serve-built-storybook": "npx http-server docs",
     "compile": "rm -rf lib && tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && npm run copy-styles && vite build"
   },

--- a/src/stories/Autocomplete/Component/index.stories.tsx
+++ b/src/stories/Autocomplete/Component/index.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof CioAutocomplete> = {
       },
     },
   },
+  tags: ['autodocs'],
 };
 
 export default meta;

--- a/src/stories/Autocomplete/Hook/Docs/Hook.mdx
+++ b/src/stories/Autocomplete/Hook/Docs/Hook.mdx
@@ -1,0 +1,138 @@
+import { Story, Canvas, Meta, Markdown } from '@storybook/blocks';
+import HooksStories from '../index.stories';
+import {HooksTemplate} from '../index.tsx';
+import SectionsType from '../Docs/Markdown/Sections.md';
+import TotalNumResultsPerSectionType from '../Docs/Markdown/TotalNumResultsPerSection.md';
+import PropGetters from '../Docs/Markdown/PropGetters.md';
+
+import {
+  apiKeyDescription,
+  cioJsClientDescription,
+  placeholderDescription,
+  customStylesDescription,
+  apiKey,
+  onSubmitDefault as onSubmit,
+  cioJsClientOptionsDescription,
+} from '../../../../constants.ts';
+
+<Meta of={HooksStories} name='Documentation' />
+
+export const generateStory = (args) => {
+return (
+  <Canvas>
+    <Story args={{ apiKey, onSubmit }}>
+      {HooksTemplate.bind({})}
+    </Story>
+  </Canvas>
+  );
+}
+
+# Hook 
+  - import \`useCioAutocomplete\` and call this custom hook in a functional component.
+  - This hook leaves rendering logic up to you, while handling:
+    - state management
+    - data fetching
+    - keyboard navigation
+    - mouse interactions
+    - focus and submit event handling
+    - accessibility
+- To use this hook, an \`apiKey\` or \`cioJsClient\` are required, and an \`onSubmit\` callback must be passed to the \`useCioAutocomplete\` hook to configure behavior. All other values are optional.
+- use the <a href="https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters" target="__blank">prop getters</a> and other variables returned by this hook (below) to leverage the functionality described above with jsx elements in your react component definitions
+
+> **Important: Please note that all of the select or submit events should go through the \`onSubmit\` callback. The \`getItemProps\` hook returns click and keyboard handlers which should be applied to the elements using the spread operator (see code examples below). Adding an \`onClick\` event manually to the elements would override the default behavior of the library preventing it from sending tracking events and would cause different behavior between click and keyboard events. Selecting an item or submitting the search would both cause \`onSubmit\` to be called.**
+
+
+## Returns
+
+> Note: any returns marked with an `*` are required to be used in the hook implementation
+
+### query \* 
+
+> `string` - Current input field value
+
+  ```jsx
+  const { query } = useCioAutocomplete(args);
+  ```
+<hr />
+
+### setQuery 
+
+> `(string) => void` - Function to update the current input field value 
+
+  ```jsx
+  const { setQuery } = useCioAutocomplete(args);
+  ```
+<hr />
+
+### isOpen 
+
+> `boolean` - Current state of the autocomplete menu 
+
+  ```jsx
+  const { isOpen } = useCioAutocomplete(args);
+  ```
+<hr />
+
+### openMenu 
+
+> `() => void` - Function to open the autocomplete menu 
+
+  ```jsx
+  const { openMenu } = useCioAutocomplete(args);
+  ```
+<hr />
+
+### closeMenu
+
+> `() => void` - Function to close the autocomplete menu 
+
+  ```jsx
+  const { closeMenu } = useCioAutocomplete(args);
+  ```
+<hr />
+
+### selectedItem
+
+> `object` - Currently selected Item (via hover or keyboard navigation) 
+
+  ```jsx
+  const { selectedItem } = useCioAutocomplete(args);
+  ```
+<hr />
+
+### sections \* 
+
+> `section[]` - Array of section data to render in menu list 
+
+  ```jsx
+  const { sections } = useCioAutocomplete(args);
+  ```
+
+<Markdown>{SectionsType}</Markdown>
+<hr />
+
+### totalNumResultsPerSection \*
+
+> `object` - Object indicating total number of results returned in each [section](#section)
+
+  ```jsx
+  const { totalNumResultsPerSection } = useCioAutocomplete(args);
+  ```
+
+<Markdown>{TotalNumResultsPerSectionType}</Markdown>
+<hr />
+
+### Prop Getters
+
+<Markdown>{PropGetters}</Markdown>
+<hr />
+
+### cioJsClient 
+
+> Constructor io client instance 
+
+Note: when we say cioJsClient, we are referring to an instance of the [constructorio-client-javascript](https://www.npmjs.com/package/@constructor-io/constructorio-client-javascript)
+
+  ```jsx
+  const { cioJsClient } = useCioAutocomplete(args);
+  ```

--- a/src/stories/Autocomplete/Hook/Docs/LiveEample.mdx
+++ b/src/stories/Autocomplete/Hook/Docs/LiveEample.mdx
@@ -1,0 +1,10 @@
+import { Meta, Controls, Canvas } from '@storybook/blocks';
+import * as HooksStories from '../index.stories';
+
+<Meta of={HooksStories} name="Live Example"/>
+
+### Interactive Live Example
+<Canvas className='live-example' sourceState='none' of={HooksStories.BasicUsage} />
+
+### Controls
+<Controls />

--- a/src/stories/Autocomplete/Hook/Docs/Markdown/CioAutocompleteProps.md
+++ b/src/stories/Autocomplete/Hook/Docs/Markdown/CioAutocompleteProps.md
@@ -1,0 +1,62 @@
+### `UserDefinedSection`
+  
+User defined Section Configurations `AutocompleteSectionConfiguration` | `RecommendationsSectionConfiguration` | `CustomSection`
+
+- by default, typing a query will fetch data for Search Suggestions and Products
+- to override this, pass an array of sections objects
+- the order of the objects in the \`sections\` array determines the order of the results
+
+  ### `AutocompleteSectionConfiguration`
+
+  Congigures the Suggestions sections for the user typed queries
+
+  | property                      | type                                    | description                                                   |
+  | :-----------------------------| :---------------------------------------| :-------------------------------------------------------------|
+  | indexSectionName              | string                                  | refers to a section under an index. The default sections are "Products" and "Search Suggestions". You can find all the sections that exist in your index under the "Indexes" tab of Constructor dashboard|
+  | type                          | 'autocomplete'                          | The type of autosuggest results in this section. Set to 'autocomplete'|
+  | displayName                   | string                                  | The display name of the section|
+  | numResults                    | number                                  | The number of results in this section. Default is 8|
+  | displaySearchTermHighlights   | boolean                                 | Use constructor's auto highlighting of words that match the search keyword, with `"displaySearchTermHighlights": true`|
+  | ref                           | object                                  | React ref object for this section|
+
+  ### `RecommendationsSectionConfiguration`
+
+  A different type of suggestions that doesn't rely on the user's typed query but returns instead "Best Search Suggestions" or "Best Products Suggestions" That is powered by Constructor's Recommendations service
+
+  | property                      | type                                    | description                                                   |
+  | :-----------------------------| :---------------------------------------| :-------------------------------------------------------------|
+  | podId                         | string                                  | Each recommendation section object must have a `podId`. You can find a list of your pods and their IDs from the customer dashboard|
+  | indexSectionName              | string                                  | refers to a section under an index. The default sections are "Products" and "Search Suggestions". You can find all the sections that exist in your index under the "Indexes" tab of Constructor dashboard|
+  | type                          | 'recommendations'                       | The type of sutosuggest results in this section. Set to 'recommendations'|
+  | displayName                   | string                                  | The display name of the section|
+  | numResults                    | number                                  | The number of results in this section. Default is 8|
+  | displaySearchTermHighlights   | boolean                                 | Use constructor's auto highlighting of words that match the search keyword, with `"displaySearchTermHighlights": true`|
+  | itemIds                       | array                                   | Array of Item IDs|
+  | term                          | string                                  | Search term|
+  | ref                           | object                                  | React ref object for this section|
+
+  ### `CustomSection`
+
+  You can directly pass any custom section with items to be renedered with other sections
+
+  | property                      | type                                    | description                                                   |
+  | :-----------------------------| :---------------------------------------| :-------------------------------------------------------------|
+  | type                          | 'custom'                                | The type of autosuggest results in this section. Set to 'custom'|
+  | displayName                   | string                                  | The display name of the section|
+  | data                          | Item[]                                  | Array of data items to be rendered|
+
+---------------------
+
+### `AdvancedParameters`
+Can be used to fine-tune the autosuggest data returned from constructor's servers.
+
+| property                             | type                                    | description                                                   |
+| :------------------------------------| :---------------------------------------| :-------------------------------------------------------------|
+| filters                               | object                                  | apply filters to the suggestions. Any parameter supported by <a href="https://docs.constructor.io/rest_api/autocomplete_queries/" target="__blank">  our autocomplete endpoint </a>  can be passed under `advancedParameters`|
+| numTermsWithGroupSuggestions         | integer                                 | Add suggested group filters to search term suggestions. Not all suggested search terms will have group filters, so these integers are upper limits, used to specify the maximum number of terms with group filters and the maximum number of suggested group filters per term|
+| numGroupsSuggestedPerTerm            | integer                                 | Add suggested group filters to search term suggestions. Not all suggested search terms will have group filters, so these integers are upper limits, used to specify the maximum number of terms with group filters and the maximum number of suggested group filters per term|
+| displaySearchSuggestionImages        | boolean                                 | Display images for search suggestions. This field need to be made displayable before they can be used. Please contact your Constructor Integration Engineer for details.|
+| displaySearchSuggestionResultCounts  | boolean                                 | Display counts for search suggestions. This field need to be made displayable before they can be used. Please contact your Constructor Integration Engineer for details.|
+| debounce                             | number                                  | override the recommended, default delay employed for debouncing autocomplete network requests between keystrokes as your users type into the text input field. The default value is 250, which results in a debounce delay of 250 milliseconds.
+| fetchZeroStateOnFocus                | boolean                                 | override the zero state fetching behavior from initial render to input focus.|
+| translations                         | object                                  | Pass a `translations` object to display translatable words in your preferred language|

--- a/src/stories/Autocomplete/Hook/Docs/Markdown/CodeExample.md
+++ b/src/stories/Autocomplete/Hook/Docs/Markdown/CodeExample.md
@@ -1,0 +1,259 @@
+### Provide API Key
+Pass an `apiKey` to request results from constructor's servers
+
+```jsx
+const args = {
+  "apiKey": "key_M57QS8SMPdLdLx4x",
+  "onSubmit": (submitEvent) => console.dir(submitEvent)
+}
+```
+---
+
+### Provide CIO Client Instance
+If you are already using an instance of the `ConstructorIOClient`, you can pass a `cioJsClient` instead of an `apiKey` to request results from constructor's servers
+
+> Note: when we say `cioJsClient`, we are referring to an instance of the [constructorio-client-javascript](https://www.npmjs.com/package/@constructor-io/constructorio-client-javascript)
+
+
+```jsx
+import ConstructorIOClient from "@constructor-io/constructorio-client-javascript";
+
+const cioJsClient = new ConstructorIOClient({ apiKey: "key_M57QS8SMPdLdLx4x" });
+const args = { cioJsClient, onSubmit: (submitEvent) => console.dir(submitEvent) };
+```
+---
+
+
+### Provide CIO Client Options
+If you don't want to create an instance of the `ConstructorIOClient` but still want to customize some of the options, you can pass a `cioJsClientOptions` object. You can learn more about the possible values [here under the parameters section](https://constructor-io.github.io/constructorio-client-javascript/ConstructorIO.html).
+
+```jsx
+const args = {
+  "apiKey": "key_M57QS8SMPdLdLx4x",
+  "cioJsClientOptions": {
+    "serviceUrl": "https://ac.cnstrc.com"
+  },
+  "onSubmit": (submitEvent) => console.dir(submitEvent)
+}
+```
+---
+
+
+### Provide Custom Styles
+By default, importing react components or hooks from this library does not pull any css into your project.
+
+If you wish to use some starter styles from this library, add an import statement similar to the example import statement below:
+
+`import '@constructor-io/constructorio-ui-autocomplete/styles.css';`
+
+- To opt out of all default styling, do not import the `styles.css` stylesheet.
+- The path and syntax in the example above may change depending on your module bundling strategy
+- These starter styles can be used as a foundation to build on top of, or just as a reference for you to replace completely.
+- All starter styles in this library are scoped within the `.cio-autocomplete` css selector.
+- These starter styles are intended to be extended by layering in your own css rules
+- If you like, you can override the container's className like so:
+`autocompleteClassName='custom-autocomplete-container'`
+- If you like, you can pass additional className(s) of your choosing like so:
+`autocompleteClassName='cio-autocomplete custom-autocomplete-container'`
+
+```css
+/* Custom Style Sheet */
+.cio-autocomplete.custom-autocomplete-styles form {
+  height: 44px;
+  width: 600px;
+  border-radius: 8px;
+  background-color: rgb(247, 247, 247);
+}
+
+.cio-autocomplete.custom-autocomplete-styles .cio-input {
+  font-weight: bold;
+}
+
+.cio-autocomplete.custom-autocomplete-styles .cio-form button {
+  width: 44px;
+}
+
+.cio-autocomplete.custom-autocomplete-styles .cio-clear-btn {
+  right: 24px;
+}
+
+.cio-autocomplete.custom-autocomplete-styles .cio-section-name {
+  margin: 5px 3px;
+}
+
+.cio-autocomplete.custom-autocomplete-styles .cio-results {
+  width: 620px;
+  max-height: 334px;
+  overflow: hidden;
+  border-radius: 0px 0px 8px 8px;
+  color: rgb(51, 51, 51);
+}
+
+.cio-autocomplete.custom-autocomplete-styles .products p {
+  padding: 5px 5px 0;
+}
+```
+---
+
+
+### Full Code Example
+Full hook usage example
+
+```jsx
+function YourComponent() {
+  const {
+    isOpen,
+    sections,
+    getFormProps,
+    getLabelProps,
+    getInputProps,
+    getMenuProps,
+    getItemProps,
+    setQuery,
+    autocompleteClassName,
+    advancedParameters,
+  } = useCioAutocomplete(args);
+  const { displaySearchSuggestionImages, displaySearchSuggestionResultCounts } =
+    advancedParameters || {};
+
+  const inputProps = getInputProps();
+
+  const renderItem = (item: Item) => {
+    const imageClassName =
+      item.section === 'Products' ? 'cio-product-image' : 'cio-suggestion-image';
+    const textClassName = item.section === 'Products' ? 'cio-product-text' : 'cio-suggestion-text';
+    let displayImage = false;
+
+    if (item.section === 'Products' && item.data?.image_url) {
+      displayImage = true;
+    }
+
+    if (item.section === 'Search Suggestions') {
+      if (displaySearchSuggestionImages && item.data?.image_url) {
+        displayImage = true;
+      }
+    }
+
+    return (
+      <div {...getItemProps(item)} key={item?.id}>
+        {displayImage && (
+          <img
+            src={item.data?.image_url}
+            alt={item.value}
+            className={imageClassName}
+            data-testid='cio-img'
+          />
+        )}
+        {item.groupName ? (
+          <p className='cio-term-in-group'>in {item.groupName}</p>
+        ) : (
+          <p className={textClassName}>{item.value}</p>
+        )}
+        {displaySearchSuggestionResultCounts && item.data?.total_num_results && (
+          <p className='cio-suggestion-count'>({item.data?.total_num_results})</p>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className={autocompleteClassName}>
+      <form {...getFormProps()}>
+        <label htmlFor='cio-input' {...getLabelProps()}>
+          <input id='cio-input' {...inputProps} />
+        </label>
+        <button
+          className='cio-clear-btn'
+          data-testid='cio-clear-btn'
+          hidden={!inputProps.value}
+          onClick={() => {
+            setQuery('');
+            if (inputProps.id) {
+              setTimeout(() => document.getElementById(inputProps.id)?.focus(), 100);
+            }
+          }}
+          type='button'
+          aria-label='Clear search field text'>
+          <div className='cio-icon'>
+            <svg
+              stroke='currentColor'
+              fill='currentColor'
+              strokeWidth='0'
+              viewBox='0 0 512 512'
+              height='1em'
+              width='1em'
+              xmlns='http://www.w3.org/2000/svg'>
+              <path d='M289.94 256l95-95A24 24 0 00351 127l-95 95-95-95a24 24 0 00-34 34l95 95-95 95a24 24 0 1034 34l95-95 95 95a24 24 0 0034-34z' />
+            </svg>
+          </div>
+        </button>
+        <button
+          className='cio-submit-btn'
+          data-testid='cio-submit-btn'
+          disabled={!inputProps.value}
+          type='submit'
+          aria-label='Submit Search'>
+          <div className='cio-icon'>
+            <svg
+              stroke='currentColor'
+              fill='currentColor'
+              strokeWidth='0'
+              viewBox='0 0 512 512'
+              height='1em'
+              width='1em'
+              xmlns='http://www.w3.org/2000/svg'>
+              <path d='M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z' />
+            </svg>
+          </div>
+        </button>
+      </form>
+      <div {...getMenuProps()}>
+        {isOpen &&
+          sections?.map((section) => {
+            if (!section?.data?.length) {
+              return null;
+            }
+
+            const { type, displayName } = section;
+            let sectionTitle: string;
+
+            switch (type) {
+              case 'recommendations':
+                sectionTitle = section.podId;
+                break;
+              case 'custom':
+                sectionTitle = displayName;
+                break;
+              case 'autocomplete':
+                sectionTitle = section.indexSectionName;
+                break;
+              default:
+                sectionTitle = section.indexSectionName;
+                break;
+            }
+
+            if (displayName) {
+              sectionTitle = displayName;
+            }
+
+            let sectionClassNames = toKebabCase(sectionTitle);
+            if (isRecommendationsSection(section)) {
+              sectionClassNames += ` ${toKebabCase(section.indexSectionName)}`;
+            }
+
+            return (
+              <div key={sectionTitle} className={sectionClassNames}>
+                <div {...getSectionProps(section)}>
+                  <h5 className='cio-section-name'>{camelToStartCase(sectionTitle)}</h5>
+                  <div className='cio-section-items'>
+                    {section?.data?.map((item) => renderItem(item))}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}
+```

--- a/src/stories/Autocomplete/Hook/Docs/Markdown/PropGetters.md
+++ b/src/stories/Autocomplete/Hook/Docs/Markdown/PropGetters.md
@@ -1,0 +1,116 @@
+  - #### `getFormProps` \*
+
+    This method should be applied to an element of type `<form>` on the autocomplete input form.
+
+      ```jsx
+      const { getFormProps } = useCioAutocomplete(args);
+
+      const ui = (
+        <form {...getFormProps()}></form>
+      );
+      ```
+
+
+  - #### `getInputProps` \*
+
+    This method should be applied to an element of type `<input>` on the autocomplete input element.
+
+      ```jsx
+      const { getInputProps } = useCioAutocomplete(args);
+
+      const ui = (
+        <input {...getInputProps()}/>
+      );
+      ```
+
+
+  - #### `getLabelProps`
+
+    This method should be applied to an element of type `<label>` on the autocomplete input label element.
+
+      ```jsx
+      const { getInputProps, getLabelProps } = useCioAutocomplete(args);
+
+      const ui = (
+        <label htmlFor='cio-input' {...getLabelProps()}>
+          <input id='cio-input' {...inputProps} />
+        </label>
+      );
+      ```
+
+  - #### `getMenuProps` \*
+
+    This method should be applied to the container element rendering the autocomplete results containers.
+
+      ```jsx
+      const { getMenuProps } = useCioAutocomplete(args);
+
+      const ui = (
+        <div {...getMenuProps()}>
+            <div>Products</div>
+            <div>Search Suggestions</div>
+        <div/>
+      );
+      ```
+
+
+  - #### `getSectionProps` \*
+
+    This method should be applied to the element rendering each autocomplete section.
+
+    It is required to pass a `section` in order to apply the logic.
+
+    - `section`: Section object for the section you are rendering.
+
+      ```jsx
+      const { sections, getMenuProps, getSectionProps } = useCioAutocomplete(args);
+
+      const ui = (
+        <div {...getMenuProps()}>
+          {sections?.map((section) => {
+            const { type, displayName } = section;
+
+            return (
+            <div {...getSectionProps(section)}>
+                <div className='cio-section-items'>
+                // List of autocomplete items here
+                </div>
+            </div>
+            );
+          })}
+        </div>
+      );
+      ```
+
+
+  - #### `getItemProps` \*
+
+    This method should be applied to the element rendering each autocomplete section item.
+
+    It is required to pass a `item` in order to apply the logic.
+
+    - `item`: item object for the item you are rendering.
+
+      ```jsx
+      const { getMenuProps, section, getSectionProps, getItemProps } = useCioAutocomplete(args);
+
+      const ui = (
+        <div {...getMenuProps()}>
+          {sections?.map((section) => {
+            const { type, displayName } = section;
+
+            return (
+            <div {...getSectionProps(section)}>
+                <div className='cio-section-items'>
+                {section?.data?.map((item) => {
+                    return (
+                    <li {...getItemProps(item)}>{item.value}</li>
+                    )
+                })}
+                </div>
+            </div>
+            );
+          })}
+        </div>
+      );
+      ```

--- a/src/stories/Autocomplete/Hook/Docs/Markdown/Sections.md
+++ b/src/stories/Autocomplete/Hook/Docs/Markdown/Sections.md
@@ -1,0 +1,13 @@
+- `section`: Section info including: 
+#### section
+
+  | property                      | type                                    | description                                                   |
+  | :-----------------------------| :---------------------------------------| :-------------------------------------------------------------|
+  | data                          | Object                                  | The item data for the current section                         |
+  | type                       | `'autocomplete'|'recommendations'|custom'` | The type of autocomplete results in this section 
+  | displayName                  | string   | The display name of the section 
+  | numResults                     | number                                  | The number of results in this section 
+  | ref                     | object                                  | React ref object for this section 
+  | indexSectionName | string                               | The name of the section (Ex: Products or Search Suggestions) 
+  | podId                | string                                | The id of the recommendation pod. Only present for recommendation sections 
+  | itemIds                 | string[]                           | The item ids used in the recommendation request. Only present for recommendation requests 

--- a/src/stories/Autocomplete/Hook/Docs/Markdown/TotalNumResultsPerSection.md
+++ b/src/stories/Autocomplete/Hook/Docs/Markdown/TotalNumResultsPerSection.md
@@ -1,0 +1,5 @@
+  | property                      | type                                    | description                                                   |
+  | :-----------------------------| :---------------------------------------| :-------------------------------------------------------------|
+  | Products                          | number                                  | The number of autocomplete items returned for Products section
+  | 'Search Suggestions'                       | number | The number of autocomplete items returned for Search Suggestions section 
+  | `<customSection>`                  | number   | The number of autocomplete items returned for any custom sections 

--- a/src/stories/Autocomplete/Hook/Docs/Props.mdx
+++ b/src/stories/Autocomplete/Hook/Docs/Props.mdx
@@ -1,0 +1,13 @@
+import { Meta, ArgTypes, Markdown } from '@storybook/blocks';
+import { RenderAutocompleteDefaultState } from '../../../tests/ComponentTests.stories';
+import * as HooksStories from '../index.stories';
+import CioAutocompleteProps from './Markdown/CioAutocompleteProps.md';
+
+<Meta of={HooksStories}  />
+
+## useCioAutocomplete Props
+<p>The props below are available to customize the autocomplete component. The `apiKey` or `cioJsClient`, and `onSubmit` callback are required props.</p>
+
+<ArgTypes of={RenderAutocompleteDefaultState} />
+
+<Markdown>{CioAutocompleteProps}</Markdown>

--- a/src/stories/Autocomplete/Hook/Docs/Usage Examples.mdx
+++ b/src/stories/Autocomplete/Hook/Docs/Usage Examples.mdx
@@ -1,0 +1,9 @@
+import { Meta, Title, Markdown } from '@storybook/blocks';
+import * as HooksStories from '../index.stories';
+import CodeExample from './Markdown/CodeExample.md';
+
+<Meta of={HooksStories} />
+
+<Title>useCioQuiz Usage Examples</Title>
+
+<Markdown>{CodeExample}</Markdown>

--- a/src/stories/Autocomplete/Hook/index.stories.tsx
+++ b/src/stories/Autocomplete/Hook/index.stories.tsx
@@ -1,81 +1,27 @@
-import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
+import type { Meta } from '@storybook/react';
 import { CioAutocomplete } from '../../../index';
-import { argTypes } from '../argTypes';
-import { functionStrings, stringifyWithDefaults } from '../../../utils';
-import { HooksTemplate, addHookStoryCode } from '.';
-import {
-  apiKeyDescription,
-  cioJsClientDescription,
-  hookDescription,
-  placeholderDescription,
-  customStylesDescription,
-  apiKey,
-  onSubmitDefault as onSubmit,
-  cioJsClientOptionsDescription,
-} from '../../../constants';
+import { argTypes, storiesControls } from '../argTypes';
+import { HooksTemplate } from '.';
+import { apiKey } from '../../../constants';
 
-export default {
+const meta: Meta<typeof HooksTemplate> = {
   title: 'Autocomplete/Hook',
   component: CioAutocomplete,
   argTypes,
   parameters: {
     docs: {
-      description: {
-        component: hookDescription,
+      source: {
+        type: 'code',
       },
     },
+    controls: storiesControls,
+  },
+  args: {
+    apiKey,
+    onsubmit,
   },
 };
 
-export const ProvideAPIKey = HooksTemplate.bind({});
-ProvideAPIKey.args = { apiKey, onSubmit };
-addHookStoryCode(
-  ProvideAPIKey,
-  `const args = ${stringifyWithDefaults(ProvideAPIKey.args)}`,
-  apiKeyDescription
-);
+export const BasicUsage = HooksTemplate.bind({});
 
-const cioJsClient = new ConstructorIOClient({ apiKey });
-
-export const ProvideCIOClientInstance = HooksTemplate.bind({});
-ProvideCIOClientInstance.args = { cioJsClient, onSubmit };
-addHookStoryCode(
-  ProvideCIOClientInstance,
-  `import ConstructorIOClient from "@constructor-io/constructorio-client-javascript";
-
-const cioJsClient = new ConstructorIOClient({ apiKey: "${apiKey}" });
-const args = { cioJsClient, onSubmit: ${functionStrings.onSubmit} };`,
-  cioJsClientDescription
-);
-
-const cioJsClientOptions = { serviceUrl: 'https://ac.cnstrc.com' };
-
-export const ProvideCIOClientOptions = HooksTemplate.bind({});
-ProvideCIOClientOptions.args = { apiKey, cioJsClientOptions, onSubmit };
-addHookStoryCode(
-  ProvideCIOClientOptions,
-  `const args = ${stringifyWithDefaults(ProvideCIOClientOptions.args)}`,
-  cioJsClientOptionsDescription
-);
-
-const placeholder = 'Custom placeholder';
-
-export const ProvideCustomPlaceHolder = HooksTemplate.bind({});
-ProvideCustomPlaceHolder.args = { apiKey, onSubmit, placeholder };
-addHookStoryCode(
-  ProvideCustomPlaceHolder,
-  `const args = ${stringifyWithDefaults(ProvideCustomPlaceHolder.args)}`,
-  placeholderDescription
-);
-
-const autocompleteClassName = 'cio-autocomplete custom-autocomplete-styles';
-
-export const ProvideCustomStyles = HooksTemplate.bind({});
-ProvideCustomStyles.args = { apiKey, onSubmit, autocompleteClassName };
-addHookStoryCode(
-  ProvideCustomStyles,
-  `import '@constructor-io/constructorio-ui-autocomplete/styles.css';
-
-const args = ${stringifyWithDefaults(ProvideCustomStyles.args)}`,
-  customStylesDescription
-);
+export default meta;

--- a/src/stories/Autocomplete/Hook/index.tsx
+++ b/src/stories/Autocomplete/Hook/index.tsx
@@ -166,7 +166,7 @@ export function HooksTemplate(args) {
   );
 }
 
-const hooksTemplateCode = `
+export const hooksTemplateCode = `
 function YourComponent() {
   const {
     isOpen,

--- a/src/stories/Autocomplete/argTypes.ts
+++ b/src/stories/Autocomplete/argTypes.ts
@@ -1,61 +1,77 @@
 // eslint-disable-next-line
 export const argTypes = {
-  placeholder: {
-    description: 'Search input placeholder',
-    table: {
-      type: {
-        summary: 'string',
-      },
-    },
+  apiKey: {
+    description: 'Your constructor API key. Either `apiKey` or `cioJsClient` are required',
     control: {
       type: 'text',
     },
   },
-  apiKey: {
-    type: { name: 'string' },
-    description: 'Your constructor API key',
-    table: {
-      type: {
-        summary: 'string',
-      },
+  cioJsClient: {
+    description:
+      'Optional custom constructor instance. Either `apiKey` or `cioJsClient` are required',
+  },
+  cioJsClientOptions: {
+    description:
+      "If you don't want to create an instance of the `ConstructorIOClient` but still want to customize some of the options, you can pass a `cioJsClientOptions` object. You can learn more about the possible values [here under the parameters section](https://constructor-io.github.io/constructorio-client-javascript/ConstructorIO.html)",
+  },
+  defaultInput: {
+    description: 'Search input default value',
+    control: {
+      type: 'text',
     },
+  },
+  placeholder: {
+    description: 'Search input placeholder',
     control: {
       type: 'text',
     },
   },
   onSubmit: {
-    type: {
-      name: 'function',
-    },
     description: `On search submit callback function`,
-    table: {
-      type: {
-        summary: 'Function',
-      },
-    },
     control: null,
   },
   onFocus: {
-    type: {
-      name: 'function',
-    },
-    description: `On focus callback function`,
-    table: {
-      type: {
-        summary: 'Function',
-      },
-    },
+    description: `On Input focus callback function`,
     control: null,
   },
   openOnFocus: {
-    description: 'Open results on focus',
-    table: {
-      type: {
-        summary: 'boolean',
-      },
-    },
+    description:
+      'Use `openOnFocus: false` to show suggestions after a user clears their query, but not when they initially apply focus to the search input field',
     control: {
       type: 'boolean',
     },
+    defaultValue: {
+      summary: 'true',
+    },
   },
+  sections: {
+    description:
+      'by default, typing a query will fetch data for Search Suggestions and Products to override this, pass an array of sections objects',
+    control: {
+      type: 'array',
+    },
+  },
+  zeroStateSections: {
+    description:
+      'Use `zeroStateSections` to show suggestions after a user applies focus to the search input field and before they start typing a query',
+    control: {
+      type: 'array',
+    },
+  },
+  autocompleteClassName: {
+    description: "Overrides the container's className",
+    control: {
+      type: 'text',
+    },
+  },
+  advancedParameters: {
+    description: 'Extra config parameters',
+    control: {
+      type: 'text',
+    },
+  },
+};
+
+export const storiesControls = {
+  include: ['apiKey', 'defaultInput', 'placeholder', 'autocompleteClassName'],
 };


### PR DESCRIPTION
Some examples of how other libraries are doing it:
- Vue: https://github.com/vuejs/core?tab=readme-ov-file#license
- React: https://github.com/facebook/react/blob/main/README.md?plain=1
- TanStack Query (they don't): https://github.com/TanStack/query?tab=MIT-1-ov-file