### PR TITLE
[CI-4265] Add License to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Ready-to-use, copy-paste examples with explanations.
 
 🔹 For more advanced use cases check the [full documentation](https://constructor-io.github.io/constructorio-ui-autocomplete/?path=/docs/autocomplete-component-advanced-parameters--docs)
 
-
 ## 📜 License
 
 [MIT License](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ Ready-to-use, copy-paste examples with explanations.
 - [Terms With Images And Counts](https://constructor-io.github.io/constructorio-ui-autocomplete/?path=/docs/autocomplete-component-advanced-parameters--docs#terms-with-images-and-counts)
 
 🔹 For more advanced use cases check the [full documentation](https://constructor-io.github.io/constructorio-ui-autocomplete/?path=/docs/autocomplete-component-advanced-parameters--docs)
+
+
+## 📜 License
+
+[MIT License](./LICENSE)
+
+Copyright (c) 2022-present Constructor.io Corporation


### PR DESCRIPTION
> Re-based from #215

Some examples of how other libraries are doing it:
- Vue: https://github.com/vuejs/core?tab=readme-ov-file#license
- React: https://github.com/facebook/react/blob/main/README.md?plain=1
- TanStack Query (they don't): https://github.com/TanStack/query?tab=MIT-1-ov-file