### PR TITLE
[CI-4786] Add removing search term on track recommendation click

### DIFF
--- a/src/hooks/useDownShift.ts
+++ b/src/hooks/useDownShift.ts
@@ -2,7 +2,11 @@ import { useCombobox, UseComboboxProps, UseComboboxReturnValue } from 'downshift
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
 import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { Item, OnSubmit } from '../types';
-import { trackSearchSubmit, trackAutocompleteSelect } from '../utils/tracking';
+import {
+  trackSearchSubmit,
+  trackAutocompleteSelect,
+  trackRecommendationSelect,
+} from '../utils/tracking';
 
 let idCounter = 0;
 
@@ -44,7 +48,7 @@ const useDownShift: UseDownShift = ({
             // Autocomplete Select tracking
             // Recommendation Select tracking
             if (selectedItem.podId && selectedItem.data?.id && selectedItem.strategy) {
-              cioClient?.tracker.trackRecommendationClick({
+              const recommendationData = {
                 itemName: selectedItem.value,
                 itemId: selectedItem.data.id,
                 variationId: selectedItem.data.variation_id,
@@ -52,7 +56,9 @@ const useDownShift: UseDownShift = ({
                 strategyId: selectedItem.strategy.id,
                 section: selectedItem.section,
                 resultId: selectedItem.result_id,
-              });
+              };
+              trackRecommendationSelect(cioClient, recommendationData);
+
               // Select tracking for all other Constructor sections:
               // (ie: Search Suggestions, Products, Custom Cio sections, etc)
               // This does not apply to custom user defined sections that aren't part of Constructor index

--- a/src/stories/tests/ComponentTests.stories.tsx
+++ b/src/stories/tests/ComponentTests.stories.tsx
@@ -399,10 +399,16 @@ SelectZeroStateRecommendationClearsSearchTermStorage.play = async ({ canvasEleme
   const recommendationItems = bestSellersSection?.querySelectorAll('[data-cnstrc-item-id]');
 
   const firstRecommendation = recommendationItems?.[0];
-  if (firstRecommendation) {
-    await userEvent.click(firstRecommendation);
-  }
+  const isSelectTrackingRequestSent = await captureTrackingRequest(
+    '/recommendation_result_click',
+    async () => {
+      if (firstRecommendation) {
+        await userEvent.click(firstRecommendation);
+      }
+    }
+  );
 
+  expect(isSelectTrackingRequestSent).toBeTruthy();
   expect(storageGetItem(CONSTANTS.SEARCH_TERM_STORAGE_KEY)).toBeNull();
 };
 

--- a/src/stories/tests/HooksTests.stories.tsx
+++ b/src/stories/tests/HooksTests.stories.tsx
@@ -2,8 +2,8 @@ import { within, userEvent, expect, fn } from '@storybook/test';
 import { CioAutocomplete } from '../../index';
 import { argTypes } from '../Autocomplete/argTypes';
 import { getCioClient, sleep } from '../../utils/helpers';
-import { isTrackingRequestSent } from '../../utils/tracking';
-import { HooksTemplate } from '../Autocomplete/Hook/index';
+import { isTrackingRequestSent, captureTrackingRequest } from '../../utils/tracking';
+import { HooksTemplate } from '../Autocomplete/Hook';
 import { apiKey, onSubmitDefault as onSubmit } from '../../constants';
 import { CioAutocompleteProps } from '../../types';
 
@@ -73,8 +73,13 @@ FocusFiresTrackingEvent.args = defaultArgs;
 FocusFiresTrackingEvent.play = async ({ canvasElement }) => {
   await sleep(100);
   const canvas = within(canvasElement);
-  await userEvent.click(canvas.getByTestId('cio-input'));
-  const isFocusTrackingRequestSent = isTrackingRequestSent('action=focus');
+  const input = canvas.getByTestId('cio-input');
+
+  // Use the reusable tracking capture utility
+  const isFocusTrackingRequestSent = await captureTrackingRequest('action=focus', async () => {
+    await userEvent.click(input);
+  });
+
   expect(isFocusTrackingRequestSent).toBeTruthy();
 };
 
@@ -435,7 +440,7 @@ InGroupSuggestions.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.type(canvas.getByTestId('cio-input'), 'socks', { delay: 100 });
   await sleep(1000);
-  expect(canvas.getAllByText('in Socks').length).toEqual(1);
+  expect(canvas.getAllByText(/in Socks/)).toHaveLength(1);
 };
 
 export const InGroupSuggestionsTwo = HooksTemplate.bind({});

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -55,3 +55,8 @@ export const trackAutocompleteSelect = (cioClient, itemName, autocompleteData: a
     storageRemoveItem(CONSTANTS.SEARCH_TERM_STORAGE_KEY);
   }
 };
+
+export const trackRecommendationSelect = (cioClient, recommendationData: any = {}) => {
+  storageRemoveItem(CONSTANTS.SEARCH_TERM_STORAGE_KEY);
+  cioClient?.tracker.trackRecommendationClick(recommendationData);
+};


### PR DESCRIPTION

This pull request adds a new utility function for tracking recommendation selections and updates the `useDownShift` hook to use this new function. The main idea is that we have removing `SEARCH_TERM_STORAGE_KEY` in `src/tracker.js` in [autocomplete-ui](https://github.com/Constructor-io/autocomplete-ui/blob/master/src/tracker.js#L437C1-L438C1), but in this library, this part is missing. I added it here, so customers who use our autocomplete library don't face issues when we send the old search term by clicking on recommendations and adding to cart. 

Also, this PR improves how recommendation clicks are tracked, making the tracking logic more modular and reusable.

**Tracking improvements:**

* Added a new `trackRecommendationSelect` function to `src/utils/tracking.ts` to encapsulate recommendation click tracking logic and ensure consistent storage cleanup.
* Updated the `useDownShift` hook in `src/hooks/useDownShift.ts` to use the new `trackRecommendationSelect` function instead of calling the tracker directly, improving maintainability and separation of concerns.
* Added `storageRemoveItem` to remove the old `SEARCH_TERM_STORAGE_KEY`