### PR TITLE
[NOCI] Bugfix: Rendering More than Expected Number of Items

### DIFF
--- a/src/components/Autocomplete/SectionItem/SectionItem.tsx
+++ b/src/components/Autocomplete/SectionItem/SectionItem.tsx
@@ -9,7 +9,6 @@ import SearchSuggestionItem from './SearchSuggestionItem';
 export interface SectionItemProps {
   item: Item;
   children?: ReactNode;
-  key?: string;
   displaySearchTermHighlights?: boolean;
 }
 

--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -14,7 +14,6 @@ export type RenderSectionItemsList = (renderResultsArguments: {
 type SectionItemsListProps = {
   section: Section;
   children?: RenderSectionItemsList;
-  key?: string;
 };
 
 // eslint-disable-next-line func-names
@@ -70,7 +69,7 @@ const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ sectio
                 renderItem={section.renderItem}
                 item={item}
                 query={query}
-                key={item.id}
+                key={item?.data?.variation_id || item?.id}
               />
             );
           }

--- a/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
+++ b/src/components/Autocomplete/SectionItemsList/SectionItemsList.tsx
@@ -77,7 +77,7 @@ const DefaultRenderSectionItemsList: RenderSectionItemsList = function ({ sectio
           return (
             <SectionItem
               item={item}
-              key={item?.id}
+              key={item?.data?.variation_id || item?.id}
               displaySearchTermHighlights={section.displaySearchTermHighlights}
             />
           );


### PR DESCRIPTION
### The Issue:
* When variation_slicing is in place, there will be multiple items in the response with the same `item_id`.
* This causes React to have trouble differentiating components, leading to unexpected rendering behavior.

### Key Changes
* Update key assignment to `SectionItem` to use `item?.data?.variation_id` as the primary key as `item.id` as the fallback
* This ensures uniqueness of key, whether variation_slicing is in place or not
* Removed `key` as an explicit prop in `SectionItemProps` and `SectionItemsListProps`
  * The `key` field is a special prop that is used by React internally and it is not being passed down to the component as part of the props object. Such, there is no need to define it in the component props explicitly.

