### PR TITLE
[NO-REF] Update Claude PR Review workflow to remove deprecated arguments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -7,6 +7,4 @@ on:
 jobs:
   review:
     uses: Constructor-io/shared-claude-code-resources-public/.github/workflows/claude-code-review.yml@main
-    with:
-      hide_previous_comments: true
     secrets: inherit


### PR DESCRIPTION
# PR Description

This PR adds the following changes:

- Removes deprecated arguments from the Claude PR review workflow
  - `hide_previous_comments`
  - `inline_comments`

**💡 note:** We recently switched to a new version of the "Claude PR Review" workflow that does inline comments by default, in order to improve the code review process. Please refer to this PR for more context: https://github.com/Constructor-io/shared-claude-code-resources/pull/39

## 🕹 Demo

Once this is merged you should see that the "Claude PR Review" workflow no longer failing, and giving you inline reviews.

You'll also see a short summary in the code review body, with all discussions extracted as inline comments in the code.

Example:

<img width="1820" height="1783" alt="image" src="https://github.com/user-attachments/assets/4f3d4913-22f0-4f91-b014-826e225cc4fd" />