### PR TITLE
[CDX-434] Add data-cnstrc-item-id attribute to Search Suggestions

### DIFF
--- a/spec/Components/CioAutocomplete/CioAutocomplete.test.tsx
+++ b/spec/Components/CioAutocomplete/CioAutocomplete.test.tsx
@@ -496,8 +496,7 @@ describe('CioAutocomplete Client-Side Rendering', () => {
       searchSuggestions.forEach((option) => {
         expect(option).toHaveAttribute(cnstrcDataAttrs.common.itemSection, 'Search Suggestions');
         expect(option).toHaveAttribute(cnstrcDataAttrs.common.itemName);
-        // Should NOT have item-id for Search Suggestions
-        expect(option).not.toHaveAttribute(cnstrcDataAttrs.common.itemId);
+        expect(option).toHaveAttribute(cnstrcDataAttrs.common.itemId);
       });
 
       // Test Product items

--- a/spec/local_examples/apiAutocompleteResponse.json
+++ b/spec/local_examples/apiAutocompleteResponse.json
@@ -3,9 +3,7 @@
     "Products": [
       {
         "matched_terms": [],
-        "labels": {
-
-        },
+        "labels": {},
         "data": {
           "id": "123",
           "url": "example.com",
@@ -18,8 +16,9 @@
     "Search Suggestions": [
       {
         "matched_terms": [],
-        "labels": {
-
+        "labels": {},
+        "data": {
+          "id": "suggestion"
         },
         "value": "suggestion"
       }

--- a/spec/utils/dataAttributeHelpers.test.ts
+++ b/spec/utils/dataAttributeHelpers.test.ts
@@ -61,6 +61,20 @@ describe('dataAttributeHelpers', () => {
       expect(attrs[cnstrcDataAttrs.common.itemId]).toBe('some-id');
     });
 
+    it('adds item-id for Search Suggestions recommendation items (zero-state SS recommendations)', () => {
+      const item = {
+        section: 'Search Suggestions',
+        value: 'Recommended Search Suggestion',
+        data: { id: 'ss-rec-123' },
+        podId: 'trending-searches',
+        strategy: { id: 'strategy-789' },
+      } as unknown as Item;
+
+      const attrs = getItemCnstrcDataAttributes(item);
+
+      expect(attrs[cnstrcDataAttrs.common.itemId]).toBe('ss-rec-123');
+    });
+
     it('adds variation-id when present', () => {
       const item = {
         section: 'Products',

--- a/spec/utils/dataAttributeHelpers.test.ts
+++ b/spec/utils/dataAttributeHelpers.test.ts
@@ -49,7 +49,7 @@ describe('dataAttributeHelpers', () => {
       expect(attrs[cnstrcDataAttrs.common.itemId]).toBe('prod-123');
     });
 
-    it('does NOT add item-id for Search Suggestions', () => {
+    it('adds item-id for Search Suggestions when data.id exists', () => {
       const item = {
         section: 'Search Suggestions',
         value: 'test query',
@@ -58,7 +58,7 @@ describe('dataAttributeHelpers', () => {
 
       const attrs = getItemCnstrcDataAttributes(item);
 
-      expect(attrs[cnstrcDataAttrs.common.itemId]).toBeUndefined();
+      expect(attrs[cnstrcDataAttrs.common.itemId]).toBe('some-id');
     });
 
     it('adds variation-id when present', () => {

--- a/src/utils/dataAttributeHelpers.ts
+++ b/src/utils/dataAttributeHelpers.ts
@@ -1,5 +1,5 @@
 import { Item, Section } from '../types';
-import { isInGroupSuggestion, isRecommendationsSection, isSearchSuggestion } from '../typeGuards';
+import { isInGroupSuggestion, isRecommendationsSection } from '../typeGuards';
 
 export const cnstrcDataAttrs = {
   common: {
@@ -70,8 +70,8 @@ export function getItemCnstrcDataAttributes(item: Item): CnstrcDataAttrs {
     [cnstrcDataAttrs.common.itemName]: item.value,
   };
 
-  // Add item ID only for non-Search Suggestions
-  if (!isSearchSuggestion(item) && item.data?.id) {
+  // Add item ID when available
+  if (item.data?.id) {
     dataCnstrc[cnstrcDataAttrs.common.itemId] = item.data.id;
   }
 


### PR DESCRIPTION
## Summary
- Removed the `isSearchSuggestion` guard from `getItemCnstrcDataAttributes` so that `data-cnstrc-item-id` is rendered for all items whenever `data.id` exists, including Search Suggestions
- This fixes zero-state SS recommendation items missing the item ID attribute, which prevented recommendation tracking events from firing
- Updated unit and component tests to reflect the new behavior, including an explicit test for zero-state SS recommendation items

Resolves [CDX-434](https://linear.app/constructor/issue/CDX-434/bug-autocomplete-ui-item-id-attribute-missing-from-ss-recommendations)

## Test plan
- [x] Unit tests pass — `data-cnstrc-item-id` is now present on Search Suggestions with `data.id`
- [x] Unit test confirms zero-state SS recommendation items get `data-cnstrc-item-id`
- [x] Component test confirms `data-cnstrc-item-id` renders on Search Suggestion DOM elements
- [x] All 69 tests pass, TypeScript type check clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>