### PR TITLE
[CDX-443] Fix rex bug with pod ID conflicts

### DIFF
--- a/spec/Components/CioAutocomplete/CioAutocomplete.test.tsx
+++ b/spec/Components/CioAutocomplete/CioAutocomplete.test.tsx
@@ -648,5 +648,84 @@ describe('CioAutocomplete Client-Side Rendering', () => {
         expect(firstItem).toHaveAttribute(cnstrcDataAttrs.recommendations.strategyId, 'bestsellers');
       }
     });
+
+    it('Renders two recommendation sections that share a podId but target different indexSectionName', async () => {
+      const cioJsClient = mockCioClientJS();
+      cioJsClient.recommendations.getRecommendations = jest.fn((podId: string, params: any) =>
+        Promise.resolve({
+          request: { section: params.section, num_results: 1, pod_id: podId },
+          response: {
+            results: [
+              {
+                data: {
+                  id: `${params.section}-id`,
+                  url: 'no-url',
+                  description: 'description',
+                  price: 1,
+                  image_url: 'example.jpg',
+                },
+                value: `${params.section}-value`,
+                strategy: { id: 'bestsellers' },
+              },
+            ],
+            total_num_results: 1,
+            pod: { id: 'bestsellers', display_name: 'Best Sellers' },
+          },
+          result_id: `result-${params.section}`,
+        })
+      );
+
+      render(
+        <CioAutocomplete
+          cioJsClient={cioJsClient}
+          onSubmit={onSubmit}
+          openOnFocus
+          zeroStateSections={[
+            { type: 'recommendations', podId: 'bestsellers', indexSectionName: 'Products' },
+            {
+              type: 'recommendations',
+              podId: 'bestsellers',
+              indexSectionName: 'Search Suggestions',
+            },
+          ]}
+        />
+      );
+
+      fireEvent.focus(screen.getByRole('combobox'));
+
+      const resultsContainer = await screen.findByTestId('cio-results', {}, { timeout: 5000 });
+
+      const recommendationContainers = await waitFor(
+        () => {
+          const containers = resultsContainer.querySelectorAll(
+            `[${cnstrcDataAttrs.recommendations.recommendationsContainer}]`
+          );
+          expect(containers.length).toBe(2);
+          return containers;
+        },
+        { timeout: 5000 }
+      );
+
+      const sections = Array.from(recommendationContainers).map((container) => {
+        const itemSections = Array.from(
+          container.querySelectorAll(`[${cnstrcDataAttrs.common.itemSection}]`)
+        ).map((el) => el.getAttribute(cnstrcDataAttrs.common.itemSection));
+        return { container, itemSections };
+      });
+
+      const productSection = sections.find((s) => s.itemSections.includes('Products'));
+      const suggestionsSection = sections.find((s) =>
+        s.itemSections.includes('Search Suggestions')
+      );
+
+      expect(productSection).toBeDefined();
+      expect(suggestionsSection).toBeDefined();
+      expect(productSection).not.toBe(suggestionsSection);
+
+      expect(productSection!.container.textContent).toContain('Products-value');
+      expect(suggestionsSection!.container.textContent).toContain('Search Suggestions-value');
+      expect(productSection!.container.textContent).not.toContain('Search Suggestions-value');
+      expect(suggestionsSection!.container.textContent).not.toContain('Products-value');
+    });
   });
 });

--- a/spec/hooks/useFetchRecommendationPod.test.tsx
+++ b/spec/hooks/useFetchRecommendationPod.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useFetchRecommendationPod from '../../src/hooks/useFetchRecommendationPod';
+import { RecommendationsSectionConfiguration } from '../../src/types';
+import { getRecommendationPodKey } from '../../src/utils/helpers';
+
+const buildResponse = (section: string) => ({
+  request: { section, num_results: 1, pod_id: 'bestsellers' },
+  response: {
+    results: [
+      {
+        data: { id: `${section}-id` },
+        value: `${section}-value`,
+        strategy: { id: 'bestsellers' },
+      },
+    ],
+    total_num_results: 1,
+    pod: { id: 'bestsellers', display_name: 'Best Sellers' },
+  },
+  result_id: `result-${section}`,
+});
+
+const makeClient = () => {
+  const getRecommendations = jest.fn((_podId: string, params: { section: string }) =>
+    Promise.resolve(buildResponse(params.section))
+  );
+  return { recommendations: { getRecommendations } } as any;
+};
+
+describe('useFetchRecommendationPod', () => {
+  it('keeps results separate when two pods share a podId but target different indexSectionName', async () => {
+    const cioClient = makeClient();
+    const pods: RecommendationsSectionConfiguration[] = [
+      { type: 'recommendations', podId: 'bestsellers', indexSectionName: 'Products' },
+      { type: 'recommendations', podId: 'bestsellers', indexSectionName: 'Search Suggestions' },
+    ];
+
+    const { result } = renderHook(() => useFetchRecommendationPod(cioClient, pods));
+
+    await waitFor(() => {
+      expect(Object.keys(result.current.recommendationsResults)).toHaveLength(2);
+    });
+
+    const productsKey = getRecommendationPodKey('bestsellers', 'Products');
+    const suggestionsKey = getRecommendationPodKey('bestsellers', 'Search Suggestions');
+
+    expect(result.current.recommendationsResults[productsKey][0].value).toBe('Products-value');
+    expect(result.current.recommendationsResults[suggestionsKey][0].value).toBe(
+      'Search Suggestions-value'
+    );
+
+    expect(result.current.podsData[productsKey].resultId).toBe('result-Products');
+    expect(result.current.podsData[suggestionsKey].resultId).toBe('result-Search Suggestions');
+  });
+
+  it('keys a single pod by composite key', async () => {
+    const cioClient = makeClient();
+    const pods: RecommendationsSectionConfiguration[] = [
+      { type: 'recommendations', podId: 'bestsellers', indexSectionName: 'Products' },
+    ];
+
+    const { result } = renderHook(() => useFetchRecommendationPod(cioClient, pods));
+
+    await waitFor(() => {
+      expect(Object.keys(result.current.recommendationsResults)).toHaveLength(1);
+    });
+
+    const key = getRecommendationPodKey('bestsellers', 'Products');
+    expect(result.current.recommendationsResults[key]).toHaveLength(1);
+    expect(result.current.podsData[key].podId).toBe('bestsellers');
+  });
+});

--- a/spec/hooks/useFetchRecommendationPod.test.tsx
+++ b/spec/hooks/useFetchRecommendationPod.test.tsx
@@ -40,8 +40,14 @@ describe('useFetchRecommendationPod', () => {
       expect(Object.keys(result.current.recommendationsResults)).toHaveLength(2);
     });
 
-    const productsKey = getRecommendationPodKey('bestsellers', 'Products');
-    const suggestionsKey = getRecommendationPodKey('bestsellers', 'Search Suggestions');
+    const productsKey = getRecommendationPodKey({
+      podId: 'bestsellers',
+      indexSectionName: 'Products',
+    });
+    const suggestionsKey = getRecommendationPodKey({
+      podId: 'bestsellers',
+      indexSectionName: 'Search Suggestions',
+    });
 
     expect(result.current.recommendationsResults[productsKey][0].value).toBe('Products-value');
     expect(result.current.recommendationsResults[suggestionsKey][0].value).toBe(
@@ -64,7 +70,7 @@ describe('useFetchRecommendationPod', () => {
       expect(Object.keys(result.current.recommendationsResults)).toHaveLength(1);
     });
 
-    const key = getRecommendationPodKey('bestsellers', 'Products');
+    const key = getRecommendationPodKey({ podId: 'bestsellers', indexSectionName: 'Products' });
     expect(result.current.recommendationsResults[key]).toHaveLength(1);
     expect(result.current.podsData[key].podId).toBe('bestsellers');
   });

--- a/spec/hooks/useNormalizedProps.test.tsx
+++ b/spec/hooks/useNormalizedProps.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import useNormalizedProps from '../../src/hooks/useNormalizedProps';
+import { UserDefinedSection } from '../../src/types';
+
+describe('useNormalizedProps', () => {
+  it('defaults indexSectionName for a recommendations section that only has a legacy identifier', () => {
+    const sections: UserDefinedSection[] = [
+      { type: 'recommendations', identifier: 'bestsellers' } as UserDefinedSection,
+    ];
+
+    const { result } = renderHook(() => useNormalizedProps({ sections }));
+
+    const [normalized] = result.current.sections as any[];
+    // Both the podId (derived from identifier) and the indexSectionName default must be applied.
+    expect(normalized.podId).toBe('bestsellers');
+    expect(normalized.indexSectionName).toBe('Products');
+  });
+
+  it('preserves an explicit indexSectionName and podId on a recommendations section', () => {
+    const sections: UserDefinedSection[] = [
+      { type: 'recommendations', podId: 'bestsellers', indexSectionName: 'Search Suggestions' },
+    ];
+
+    const { result } = renderHook(() => useNormalizedProps({ sections }));
+
+    const [normalized] = result.current.sections as any[];
+    expect(normalized.podId).toBe('bestsellers');
+    expect(normalized.indexSectionName).toBe('Search Suggestions');
+  });
+});

--- a/spec/utils/tracking.test.ts
+++ b/spec/utils/tracking.test.ts
@@ -1,0 +1,68 @@
+import { trackRecommendationView } from '../../src/utils/tracking';
+import { RecommendationsSection } from '../../src/types';
+
+const makeSection = (indexSectionName: string): RecommendationsSection =>
+  ({
+    type: 'recommendations',
+    podId: 'bestsellers',
+    indexSectionName,
+    data: [{ value: `${indexSectionName}-value`, data: { id: `${indexSectionName}-id` } }],
+  }) as unknown as RecommendationsSection;
+
+const makeTarget = (dataset: Record<string, string | undefined>) => {
+  const target = document.createElement('div');
+  Object.entries(dataset).forEach(([key, value]) => {
+    if (value !== undefined) target.dataset[key] = value;
+  });
+  return target;
+};
+
+const makeClient = () => {
+  const trackRecommendationViewSpy = jest.fn();
+  return {
+    client: { tracker: { trackRecommendationView: trackRecommendationViewSpy } } as any,
+    trackRecommendationViewSpy,
+  };
+};
+
+describe('trackRecommendationView', () => {
+  const sections = [makeSection('Products'), makeSection('Search Suggestions')];
+
+  it('matches the section whose podKey matches podId + section, not just podId', () => {
+    const { client, trackRecommendationViewSpy } = makeClient();
+    const target = makeTarget({
+      cnstrcRecommendationsPodId: 'bestsellers',
+      cnstrcSection: 'Search Suggestions',
+    });
+
+    trackRecommendationView(target, sections, client);
+
+    expect(trackRecommendationViewSpy).toHaveBeenCalledTimes(1);
+    const payload = trackRecommendationViewSpy.mock.calls[0][0];
+    expect(payload.section).toBe('Search Suggestions');
+    expect(payload.numResultsViewed).toBe(1);
+    expect(payload.items).toEqual([
+      {
+        itemId: 'Search Suggestions-id',
+        itemName: 'Search Suggestions-value',
+        variationId: undefined,
+      },
+    ]);
+  });
+
+  it('does not match any section when section attribute is missing (no arbitrary first-pod match)', () => {
+    const { client, trackRecommendationViewSpy } = makeClient();
+    const target = makeTarget({ cnstrcRecommendationsPodId: 'bestsellers' });
+
+    trackRecommendationView(target, sections, client);
+
+    expect(trackRecommendationViewSpy).toHaveBeenCalledTimes(1);
+    const payload = trackRecommendationViewSpy.mock.calls[0][0];
+    // Missing cnstrcSection resolves to the default ('Products') podKey, so it matches the
+    // Products section deterministically rather than arbitrarily grabbing the first pod.
+    expect(payload.numResultsViewed).toBe(1);
+    expect(payload.items).toEqual([
+      { itemId: 'Products-id', itemName: 'Products-value', variationId: undefined },
+    ]);
+  });
+});

--- a/src/components/Autocomplete/AutocompleteResults/AutocompleteResults.tsx
+++ b/src/components/Autocomplete/AutocompleteResults/AutocompleteResults.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode, useContext } from 'react';
 import { Item, Section } from '../../../types';
 import { toKebabCase } from '../../../utils/format';
+import { getRecommendationPodKey } from '../../../utils/helpers';
 import { CioAutocompleteContext } from '../CioAutocompleteProvider';
 import SectionItemsList from '../SectionItemsList/SectionItemsList';
 import CloseIcon from './CloseIcon';
@@ -21,7 +22,7 @@ const DefaultRenderResults: RenderResults = ({ sections }) =>
 
     switch (type) {
       case 'recommendations':
-        key = section.podId;
+        key = getRecommendationPodKey(section.podId, section.indexSectionName);
         break;
       case 'custom':
         key = toKebabCase(section.displayName);

--- a/src/components/Autocomplete/AutocompleteResults/AutocompleteResults.tsx
+++ b/src/components/Autocomplete/AutocompleteResults/AutocompleteResults.tsx
@@ -22,7 +22,7 @@ const DefaultRenderResults: RenderResults = ({ sections }) =>
 
     switch (type) {
       case 'recommendations':
-        key = getRecommendationPodKey(section.podId, section.indexSectionName);
+        key = getRecommendationPodKey(section);
         break;
       case 'custom':
         key = toKebabCase(section.displayName);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,10 @@ import { AutocompleteSubmitEvent } from './types';
 // Autocomplete key index
 export const apiKey = 'key_M57QS8SMPdLdLx4x';
 
+// Default `indexSectionName` assigned to recommendation sections when one isn't configured.
+// Shared between normalization (useNormalizedProps) and cache keying (helpers) to prevent drift.
+export const DEFAULT_RECOMMENDATION_INDEX_SECTION = 'Products';
+
 /// //////////////////////////////
 // Storybook Folder Descriptions
 /// //////////////////////////////

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -314,8 +314,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
 
       // Add data attributes for recommendations using helper
       if (isRecommendationsSection(section)) {
-        const podData =
-          podsData?.[getRecommendationPodKey(section.podId, section.indexSectionName)];
+        const podData = podsData?.[getRecommendationPodKey(section)];
         const seedItems = normalizeSeedItems(section.itemIds);
 
         const recommendationAttributes = getRecommendationsSectionCnstrcDataAttributes(

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -302,7 +302,9 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
         className: `cio-section cio-section-${sectionListingType} ${getDeprecatedClassNames()}`,
         ref: section.ref,
         role: 'none',
-        [cnstrcDataAttrs.common.section]: section.data[0]?.section,
+        [cnstrcDataAttrs.common.section]:
+          section.data[0]?.section ||
+          (isRecommendationsSection(section) ? section.indexSectionName : undefined),
       };
 
       if (isCustomSection(section)) {

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -304,7 +304,7 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
         role: 'none',
         [cnstrcDataAttrs.common.section]:
           section.data[0]?.section ||
-          (isRecommendationsSection(section) ? section.indexSectionName : undefined),
+          (isCustomSection(section) ? undefined : section.indexSectionName),
       };
 
       if (isCustomSection(section)) {

--- a/src/hooks/useCioAutocomplete.ts
+++ b/src/hooks/useCioAutocomplete.ts
@@ -14,7 +14,11 @@ import {
   OnSubmit,
 } from '../types';
 import usePrevious from './usePrevious';
-import { getItemPosition, getItemsForActiveSections } from '../utils/helpers';
+import {
+  getItemPosition,
+  getItemsForActiveSections,
+  getRecommendationPodKey,
+} from '../utils/helpers';
 import { toKebabCase } from '../utils/format';
 import { trackRecommendationView, trackSearchSubmit } from '../utils/tracking';
 import { getFeatures } from '../utils/features';
@@ -308,7 +312,8 @@ const useCioAutocomplete = (options: UseCioAutocompleteOptions) => {
 
       // Add data attributes for recommendations using helper
       if (isRecommendationsSection(section)) {
-        const podData = podsData?.[section.podId];
+        const podData =
+          podsData?.[getRecommendationPodKey(section.podId, section.indexSectionName)];
         const seedItems = normalizeSeedItems(section.itemIds);
 
         const recommendationAttributes = getRecommendationsSectionCnstrcDataAttributes(

--- a/src/hooks/useFetchRecommendationPod.ts
+++ b/src/hooks/useFetchRecommendationPod.ts
@@ -29,9 +29,11 @@ const useFetchRecommendationPod = (
     responses.forEach(({ response, request, result_id: resultId }, index) => {
       const { pod, results } = response;
       if (pod?.id) {
-        const sectionName =
-          recommendationPods[index]?.indexSectionName ?? DEFAULT_RECOMMENDATION_INDEX_SECTION;
-        const podKey = getRecommendationPodKey(pod.id, sectionName);
+        const sectionConfig = recommendationPods[index];
+        const sectionName = sectionConfig?.indexSectionName ?? DEFAULT_RECOMMENDATION_INDEX_SECTION;
+        // Key by the configured podId (not the API-returned pod.id) so write and read
+        // sites — which all derive the key from the configured podId — stay consistent.
+        const podKey = getRecommendationPodKey(sectionConfig);
         recommendationsPodResults[podKey] = results?.map((item) => ({
           ...item,
           id: item?.data?.id,

--- a/src/hooks/useFetchRecommendationPod.ts
+++ b/src/hooks/useFetchRecommendationPod.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
 import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { SectionsData, RecommendationsSectionConfiguration, PodData } from '../types';
+import { getRecommendationPodKey } from '../utils/helpers';
 
 const useFetchRecommendationPod = (
   cioClient: Nullable<ConstructorIOClient>,
@@ -27,13 +28,15 @@ const useFetchRecommendationPod = (
     responses.forEach(({ response, request, result_id: resultId }, index) => {
       const { pod, results } = response;
       if (pod?.id) {
-        recommendationsPodResults[pod.id] = results?.map((item) => ({
+        const indexSectionName = recommendationPods[index]?.indexSectionName;
+        const podKey = getRecommendationPodKey(pod.id, indexSectionName);
+        recommendationsPodResults[podKey] = results?.map((item) => ({
           ...item,
           id: item?.data?.id,
-          section: recommendationPods[index]?.indexSectionName,
+          section: indexSectionName,
           podId: pod.id,
         }));
-        recommendationsPodsData[pod.id] = {
+        recommendationsPodsData[podKey] = {
           displayName: pod.display_name,
           podId: pod.id,
           request,

--- a/src/hooks/useFetchRecommendationPod.ts
+++ b/src/hooks/useFetchRecommendationPod.ts
@@ -3,6 +3,7 @@ import ConstructorIOClient from '@constructor-io/constructorio-client-javascript
 import { Nullable } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { SectionsData, RecommendationsSectionConfiguration, PodData } from '../types';
 import { getRecommendationPodKey } from '../utils/helpers';
+import { DEFAULT_RECOMMENDATION_INDEX_SECTION } from '../constants';
 
 const useFetchRecommendationPod = (
   cioClient: Nullable<ConstructorIOClient>,
@@ -19,7 +20,7 @@ const useFetchRecommendationPod = (
       recommendationPods.map(({ podId, indexSectionName, ...parameters }) =>
         cioClient.recommendations.getRecommendations(podId, {
           ...parameters,
-          section: indexSectionName,
+          section: indexSectionName ?? DEFAULT_RECOMMENDATION_INDEX_SECTION,
         })
       )
     );
@@ -28,12 +29,13 @@ const useFetchRecommendationPod = (
     responses.forEach(({ response, request, result_id: resultId }, index) => {
       const { pod, results } = response;
       if (pod?.id) {
-        const indexSectionName = recommendationPods[index]?.indexSectionName;
-        const podKey = getRecommendationPodKey(pod.id, indexSectionName);
+        const sectionName =
+          recommendationPods[index]?.indexSectionName ?? DEFAULT_RECOMMENDATION_INDEX_SECTION;
+        const podKey = getRecommendationPodKey(pod.id, sectionName);
         recommendationsPodResults[podKey] = results?.map((item) => ({
           ...item,
           id: item?.data?.id,
-          section: indexSectionName,
+          section: sectionName,
           podId: pod.id,
         }));
         recommendationsPodsData[podKey] = {

--- a/src/hooks/useNormalizedProps.ts
+++ b/src/hooks/useNormalizedProps.ts
@@ -2,6 +2,7 @@
 import { useMemo } from 'react';
 import { UseCioAutocompleteOptions, UserDefinedSection } from '../types';
 import { isAutocompleteSection, isRecommendationsSection } from '../typeGuards';
+import { DEFAULT_RECOMMENDATION_INDEX_SECTION } from '../constants';
 
 export const defaultSections: UserDefinedSection[] = [
   {
@@ -22,7 +23,7 @@ const convertLegacyParametersAndAddDefaults = (sections: UserDefinedSection[]) =
       }
 
       if (!config.indexSectionName) {
-        return { ...config, indexSectionName: 'Products' };
+        return { ...config, indexSectionName: DEFAULT_RECOMMENDATION_INDEX_SECTION };
       }
     }
 

--- a/src/hooks/useNormalizedProps.ts
+++ b/src/hooks/useNormalizedProps.ts
@@ -18,13 +18,11 @@ export const defaultSections: UserDefinedSection[] = [
 const convertLegacyParametersAndAddDefaults = (sections: UserDefinedSection[]) =>
   sections.map((config) => {
     if (isRecommendationsSection(config)) {
-      if (config.identifier && !config.podId) {
-        return { ...config, podId: config.identifier };
-      }
-
-      if (!config.indexSectionName) {
-        return { ...config, indexSectionName: DEFAULT_RECOMMENDATION_INDEX_SECTION };
-      }
+      return {
+        ...config,
+        podId: config.podId ?? config.identifier,
+        indexSectionName: config.indexSectionName ?? DEFAULT_RECOMMENDATION_INDEX_SECTION,
+      };
     }
 
     if (isAutocompleteSection(config)) {

--- a/src/hooks/useSections/index.ts
+++ b/src/hooks/useSections/index.ts
@@ -38,7 +38,7 @@ export default function useSections(
 
   // Access the Pods Data from the Recommendations response to update Active Sections configuration
   useEffect(() => {
-    if (!recommendations.podsData) {
+    if (recommendations.podsData) {
       setPodsData(recommendations.podsData);
     }
   }, [recommendations.podsData]);

--- a/src/hooks/useSections/useActiveSections.ts
+++ b/src/hooks/useSections/useActiveSections.ts
@@ -22,8 +22,7 @@ export default function useActiveSections(
         const mergedConfig = config;
 
         if (isRecommendationsSection(config)) {
-          const podData =
-            podsData?.[getRecommendationPodKey(config.podId, config.indexSectionName)];
+          const podData = podsData?.[getRecommendationPodKey(config)];
           const libraryDisplayName = config.displayName;
           const dashboardDisplayName = podData?.displayName;
 

--- a/src/hooks/useSections/useActiveSections.ts
+++ b/src/hooks/useSections/useActiveSections.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import { PodData, UserDefinedSection } from '../../types';
 import { isRecommendationsSection } from '../../typeGuards';
+import { getRecommendationPodKey } from '../../utils/helpers';
 
 export default function useActiveSections(
   query: string,
@@ -21,7 +22,8 @@ export default function useActiveSections(
         const mergedConfig = config;
 
         if (isRecommendationsSection(config)) {
-          const podData = podsData?.[config.podId];
+          const podData =
+            podsData?.[getRecommendationPodKey(config.podId, config.indexSectionName)];
           const libraryDisplayName = config.displayName;
           const dashboardDisplayName = podData?.displayName;
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,7 @@
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
 import { ConstructorClientOptions } from '@constructor-io/constructorio-client-javascript/lib/types';
 import { Item, Section, UserDefinedSection, SectionsData, Translations, PodData } from '../types';
+import { DEFAULT_RECOMMENDATION_INDEX_SECTION } from '../constants';
 import version from '../version';
 
 export type GetItemPosition = (args: { item: Item; items: Item[] }) => {
@@ -83,7 +84,7 @@ export const getCioClient = (apiKey?: string, cioClientOptions?: ConstructorClie
 };
 
 export const getRecommendationPodKey = (podId: string, indexSectionName?: string) =>
-  `${podId}::${indexSectionName ?? 'Products'}`;
+  `${podId}::${indexSectionName ?? DEFAULT_RECOMMENDATION_INDEX_SECTION}`;
 
 export const getActiveSectionsWithData = (
   activeSections: UserDefinedSection[],

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -82,6 +82,9 @@ export const getCioClient = (apiKey?: string, cioClientOptions?: ConstructorClie
   return null;
 };
 
+export const getRecommendationPodKey = (podId: string, indexSectionName?: string) =>
+  `${podId}::${indexSectionName ?? 'Products'}`;
+
 export const getActiveSectionsWithData = (
   activeSections: UserDefinedSection[],
   sectionsResults: SectionsData,
@@ -96,7 +99,10 @@ export const getActiveSectionsWithData = (
 
     switch (type) {
       case 'recommendations':
-        sectionData = sectionsResults[sectionConfig.podId];
+        sectionData =
+          sectionsResults[
+            getRecommendationPodKey(sectionConfig.podId, sectionConfig.indexSectionName)
+          ];
         break;
       case 'custom':
         // Copy id from data to the top level
@@ -123,8 +129,8 @@ export const getActiveSectionsWithData = (
       };
 
       if (sectionConfig.type === 'recommendations') {
-        section.displayName =
-          sectionConfig.displayName || podsData[sectionConfig.podId].displayName;
+        const podKey = getRecommendationPodKey(sectionConfig.podId, sectionConfig.indexSectionName);
+        section.displayName = sectionConfig.displayName || podsData[podKey].displayName;
       }
 
       // If ref passed as part of `SectionConfiguration`, use it.

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,14 @@
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript';
 import { ConstructorClientOptions } from '@constructor-io/constructorio-client-javascript/lib/types';
-import { Item, Section, UserDefinedSection, SectionsData, Translations, PodData } from '../types';
+import {
+  Item,
+  Section,
+  UserDefinedSection,
+  SectionsData,
+  Translations,
+  PodData,
+  RecommendationsSectionConfiguration,
+} from '../types';
 import { DEFAULT_RECOMMENDATION_INDEX_SECTION } from '../constants';
 import version from '../version';
 
@@ -83,7 +91,10 @@ export const getCioClient = (apiKey?: string, cioClientOptions?: ConstructorClie
   return null;
 };
 
-export const getRecommendationPodKey = (podId: string, indexSectionName?: string) =>
+export const getRecommendationPodKey = ({
+  podId,
+  indexSectionName,
+}: Pick<RecommendationsSectionConfiguration, 'podId' | 'indexSectionName'>) =>
   `${podId}::${indexSectionName ?? DEFAULT_RECOMMENDATION_INDEX_SECTION}`;
 
 export const getActiveSectionsWithData = (
@@ -100,10 +111,7 @@ export const getActiveSectionsWithData = (
 
     switch (type) {
       case 'recommendations':
-        sectionData =
-          sectionsResults[
-            getRecommendationPodKey(sectionConfig.podId, sectionConfig.indexSectionName)
-          ];
+        sectionData = sectionsResults[getRecommendationPodKey(sectionConfig)];
         break;
       case 'custom':
         // Copy id from data to the top level
@@ -130,7 +138,7 @@ export const getActiveSectionsWithData = (
       };
 
       if (sectionConfig.type === 'recommendations') {
-        const podKey = getRecommendationPodKey(sectionConfig.podId, sectionConfig.indexSectionName);
+        const podKey = getRecommendationPodKey(sectionConfig);
         section.displayName = sectionConfig.displayName || podsData[podKey]?.displayName;
       }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -130,7 +130,7 @@ export const getActiveSectionsWithData = (
 
       if (sectionConfig.type === 'recommendations') {
         const podKey = getRecommendationPodKey(sectionConfig.podId, sectionConfig.indexSectionName);
-        section.displayName = sectionConfig.displayName || podsData[podKey].displayName;
+        section.displayName = sectionConfig.displayName || podsData[podKey]?.displayName;
       }
 
       // If ref passed as part of `SectionConfiguration`, use it.

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -2,6 +2,7 @@ import { Nullable } from '@constructor-io/constructorio-client-javascript';
 import ConstructorIOClient from '@constructor-io/constructorio-client-javascript/lib/types/constructorio';
 import { isRecommendationsSection } from '../typeGuards';
 import { Section } from '../types';
+import { getRecommendationPodKey } from './helpers';
 
 // eslint-disable-next-line import/no-cycle
 import { CONSTANTS, storeRecentSearch, storeRecentAction } from './beaconUtils';
@@ -22,13 +23,16 @@ export const trackRecommendationView = (
   cioClient: Nullable<ConstructorIOClient>
 ) => {
   if (target.dataset.cnstrcRecommendationsPodId) {
-    // Pull recommendations from activeSectionsWithData by podId + section, since a
-    // single podId may be reused across multiple sections (e.g. Products vs. Search Suggestions)
+    // Match by composite podKey (podId + indexSectionName), since a single podId may be
+    // reused across multiple sections (e.g. Products vs. Search Suggestions). Both sides
+    // funnel through getRecommendationPodKey so the default section handling stays consistent.
+    const targetPodKey = getRecommendationPodKey({
+      podId: target.dataset.cnstrcRecommendationsPodId,
+      indexSectionName: target.dataset.cnstrcSection,
+    });
     const recommendationSection = activeSectionsWithData.find(
       (section) =>
-        isRecommendationsSection(section) &&
-        section.podId === target.dataset.cnstrcRecommendationsPodId &&
-        (!target.dataset.cnstrcSection || section.indexSectionName === target.dataset.cnstrcSection)
+        isRecommendationsSection(section) && getRecommendationPodKey(section) === targetPodKey
     );
     const recommendationItems = recommendationSection?.data.map((item) => ({
       itemId: item.data?.id,

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -28,7 +28,7 @@ export const trackRecommendationView = (
       (section) =>
         isRecommendationsSection(section) &&
         section.podId === target.dataset.cnstrcRecommendationsPodId &&
-        (!target.dataset.cnstrcSection || section.data[0]?.section === target.dataset.cnstrcSection)
+        (!target.dataset.cnstrcSection || section.indexSectionName === target.dataset.cnstrcSection)
     );
     const recommendationItems = recommendationSection?.data.map((item) => ({
       itemId: item.data?.id,

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -22,11 +22,13 @@ export const trackRecommendationView = (
   cioClient: Nullable<ConstructorIOClient>
 ) => {
   if (target.dataset.cnstrcRecommendationsPodId) {
-    // Pull recommendations from activeSectionsWithData by podId surfaced on target
+    // Pull recommendations from activeSectionsWithData by podId + section, since a
+    // single podId may be reused across multiple sections (e.g. Products vs. Search Suggestions)
     const recommendationSection = activeSectionsWithData.find(
       (section) =>
         isRecommendationsSection(section) &&
-        section.podId === target.dataset.cnstrcRecommendationsPodId
+        section.podId === target.dataset.cnstrcRecommendationsPodId &&
+        (!target.dataset.cnstrcSection || section.data[0]?.section === target.dataset.cnstrcSection)
     );
     const recommendationItems = recommendationSection?.data.map((item) => ({
       itemId: item.data?.id,


### PR DESCRIPTION
Two recommendation pods with the same `podId` but different `indexSectionName` (e.g. `bestsellers` targeting both `Products` and `Search Suggestions`) were collapsing into a single result set because the internal cache was keyed by `podId` alone.

`useFetchRecommendationPod` wrote both `recommendationsResults` and `podsData` as `{ [podId]: ... }`. The second API response silently overwrote the first, and every downstream reader (helpers, `useActiveSections`, `useCioAutocomplete`, React keys, view tracking) inherited the collision.

- New `getRecommendationPodKey(podId, indexSectionName)` helper producing `${podId}::${indexSectionName ?? 'Products'}`, threaded through every write and read site.
- Fixed inverted guard in `useSections` (`if (!podsData)` → `if (podsData)`) so the local state actually hydrates.
- `trackRecommendationView` now disambiguates on `podId` + `indexSectionName` so view events attribute to the correct section.
- `data-cnstrc-section` on recommendation containers falls back to `indexSectionName` when the pod returns zero results.

## Breaking change
`podsData` returned from `useCioAutocomplete` is now keyed by the composite key instead of bare `podId`. External consumers reading this map by bare `podId` will need to update the lookup.

Public types, SDK request shape, and tracking payload are unchanged.
